### PR TITLE
chore(archive): demote updates/ archive notes from memo (draft:true, not deleted)

### DIFF
--- a/updates/OGIF/1-20240405.md
+++ b/updates/OGIF/1-20240405.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #1: markdown presentations, research content pipeline, and professional screenshots"
 short_title: "#1 Markdown Presentations, Research Pipeline, Screenshots How-to"
 description: "Our first ever Office Hours in our series of OGIFs. Our first day to exchange knowledge and insights on topics and projects we're working on and tools we're using for our internal work and clients."

--- a/updates/OGIF/10-20240614.md
+++ b/updates/OGIF/10-20240614.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #10 - behavioral patterns and map content organization"
 short_title: "#10 Behavioral Patterns and Map Content Organization"
 description: "Join us for our tenth office hours session to discuss behavioral design patterns and effective map content organization! We'll also catch you up on important June updates. Bring your questions and ideas, we want to hear from you."

--- a/updates/OGIF/11-20240621.md
+++ b/updates/OGIF/11-20240621.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #11 - Design patterns: template method & visitor, Radix sort, and weekly tech commentary"
 short_title: "#11 Design patterns: template method & visitor, Radix sort, and weekly tech commentary"
 description: Join us for our evleventh community discussion on design patterns (Template Method and Visitor), Radix Sort, and the latest tech news. The discussion will be guided by weekly topics selected through community input, fostering a collaborative learning environment for all participants.

--- a/updates/OGIF/12-20240628.md
+++ b/updates/OGIF/12-20240628.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF Office Hours #12 - Community June updates, Project progress, Go Weekly: Mastering Go Performance - eBPF and PGO Optimization Techniques, Multimodal in RAG (Retrieval Augmented Generation)"
 short_title: "#12 June updates, Go Performance, eBPF, PGO, Multimodal RAG"
 description: In June community call, we kicked off with an introduction to the themes for knowledge reinforcement. We provide a summary of recent activities and topics, including blockchain, optimization, and news updates. Weekly Go updates cover optimization techniques, followed by an introduction to Solana blockchain concepts. The session concludes with a demonstration on handling multimodal data using LangChain.

--- a/updates/OGIF/13-20240705.md
+++ b/updates/OGIF/13-20240705.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #13 - Go Weekly updates, Radix sort, Human feedback mechanism, and effective ChatGPT usage"
 short_title: "#13 Go Weekly updates, Radix Sort, Human Feedback Mechanism, and effective ChatGPT usage"
 description: "This week's OGIF covers key topics including Go Weekly updates, Radix Sort, Human Feedback Mechanism, and effective ChatGPT usage. We discuss Go iterators and the latest features in Go 1.23, followed by a demonstration of Radix Sort's efficiency. The session also explains the Human Feedback Mechanism for improving Chatbot models and wraps up with best practices for using ChatGPT effectively."

--- a/updates/OGIF/14-20240712.md
+++ b/updates/OGIF/14-20240712.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #14 - generic collections, pricing models, and OGIF summarizer"
 short_title: "#14 Generic Collections, Pricing Models, and OGIF Summarizer"
 description: In our fourteenth covers work distribution, enhanced article writing, product development, and strategic pricing models. It also discusses generics in Go, Dolt for database version control, and an automated tool for OGIF summaries, offering insights for developers and project managers.

--- a/updates/OGIF/15-20240719.md
+++ b/updates/OGIF/15-20240719.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #15 - Architecting AI supervisors, local-first software, AI code completion overview and crawl list bot command"
 short_title: "#15 AI Supervisors, Local-first Software, Code Completion, Bot Commands"
 description: "In our fifteenth community discussion, we focus on Architecting AI Supervisors, Local-First Software and Crawl list command. Topics include an overview of ongoing projects, a detailed look at various code completion tools, and a demonstration of the Supervisor architecture. Additionally, we'll review the local-first software paradigm and conclude with a summary of new features and team contributions."

--- a/updates/OGIF/16-20240726.md
+++ b/updates/OGIF/16-20240726.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF Office Hours #16 - Golang weekly #4, TIL in Dune's query, AI voice clone demo and Re-ranking in RAG system."
 short_title: "#16 Go weekly, Dune query, AI voice clone, RAG re-ranking"
 description: "Our sixteenth office hours community discussion will cover a range of topics including Golang commentary updates, insights on TIL in Dune's query, a demo of AI voice cloning, and advancements in re-ranking within the RAG system. Join us for an engaging session designed to promote collaborative learning and growth among our members."

--- a/updates/OGIF/17-20240802.md
+++ b/updates/OGIF/17-20240802.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #17 - community call July, C4 model, and interview life in the US"
 short_title: "#17 Community Call July, C4 Model, Interview Life in the US"
 description: 'Join us for our seventeenth OGIF community call on Aug 2nd, where we''ll discuss the current state of technology investment in Vietnam, introduce a new referral and commission model for the team, present the C4 model for subscription systems, and interview Hieu about his experience living in the US. We''ll wrap up with plans for next week''s meeting. This session will be guided by topics selected through community input, promoting a collaborative and insightful environment for all participants."'

--- a/updates/OGIF/18-20240809.md
+++ b/updates/OGIF/18-20240809.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #18 - Golang weekly, Devbox MOC, search retrieval in RAG, generative UI, FE monthly #1"
 short_title: "#18 Go weekly, RAG, UI, FE updates"
 description: "OGIF 18 covers key discussions on Golang weekly #6, insights into search retrieval in RAG, advancements in generative UI, and the first edition of FE monthly. This edition provides valuable updates for developers and tech enthusiasts, offering a deep dive into the latest trends and techniques in software development."

--- a/updates/OGIF/19-20240821.md
+++ b/updates/OGIF/19-20240821.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Ogif office hours #19 - Golang weekly, designing for forgiveness, file sharing system design, Dify AI demo"
 short_title: "#19 Go weekly, UI design, File sharing, Dify AI"
 description: OGIF 19 dives into essential topics including Go 1.23 updates, effective UI error handling, and a detailed Dify AI demo. We explore common Go pitfalls, best practices for database design, and strategies for optimizing queries. The session also features a practical demonstration of integrating AI into development workflows with Dify AI.

--- a/updates/OGIF/2-20240412.md
+++ b/updates/OGIF/2-20240412.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #2: Devbox as the new Docker, security standards, and understanding liquidity"
 short_title: "#2 Devbox as the new Docker, Security Standards, and Understanding Liquidity"
 description: Our second Office Hours. Join the community to exchange knowledge and insights on diverse topics, including Docker alternatives with Nix, security practices and origin stories of our standards, financial discussions on liquidity, company updates, and icy draws.

--- a/updates/OGIF/20-20240823.md
+++ b/updates/OGIF/20-20240823.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #20 - Golang weekly, modeling dynamic object properties, Devbox demo, LLM tracing, Cursor AI editor"
 short_title: "#20 Go weekly, Dynamic objects, Devbox, LLM tracing, Cursor AI"
 description: Our latest OGIF session covers key topics such as Go 1.23 and the introduction of Go Notebook, dynamic object modeling inspired by Notion, advanced LLM tracing techniques, Devbox demo and a hands-on look at the Cursor AI code editor. By sharing weekly topics chosen through tags, we foster a collaborative learning environment for our community to grow.

--- a/updates/OGIF/21-20240830.md
+++ b/updates/OGIF/21-20240830.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #21 - Community engagement, Go weekly, Journey of thought for prompt engineering"
 short_title: "#21 Community engagement, Go weekly, Journey of thought for prompt engineering"
 description: Our latest community discussion covers key topics such as increasing community engagement, the introduction of the DFG token for contribution recognition, building an internet brand, and market trends toward AI and tech advancements. We’ll also explore small tool development for monetization and insights on reducing software development costs with new technologies. Join us to learn more about upcoming initiatives and activities.

--- a/updates/OGIF/22-20240906.md
+++ b/updates/OGIF/22-20240906.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF Office Hours #22 - Hybrid working, Tech market report, Go commentary weekly, AI demo for Go weekly content production."
 short_title: "#22 Hybrid work, Tech report, Go weekly, AI demo"
 description: In OGIF 22, we talked about Devbox progress, GReader updates, and using libre chat for artifact management. We also cover optimizing AI system prompts, Go commentary, and key market trends. Plus, we discuss how hybrid work can boost team collaboration and productivity. It’s all about practical tips and knowledge sharing to keep everyone up to speed.

--- a/updates/OGIF/23-20240913.md
+++ b/updates/OGIF/23-20240913.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #23 - Go weekly, frontend report, hybrid working support, and AI mixture agent"
 short_title: "#23 Go weekly, FE report, Hybrid work, AI agents"
 description: In OGIF Office Hour 23 covered a variety of topics, including updates on Golang Weekly and its use in enterprise environments, comparing Go with Java and C++. The session explored the latest trends in React 19 AC, Next.js, and CSS Grid, alongside new form-building tools. Additionally, the team discussed productivity enhancements using AI-driven solutions like mixture agents, while introducing upcoming tests and hybrid work support.

--- a/updates/OGIF/24-20240920.md
+++ b/updates/OGIF/24-20240920.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #24 - Go weekly, AI-driven workflows, holistic team AI demo, and Figma to UI component with Claude"
 short_title: "#24 Go weekly, AI workflows, Team AI demo, Figma-UI with Claude"
 description: "In our OGIF office hour 24 covers AI-driven workflows with Tom, a demo with the Holistic team, and Figma integration with Claude for UI components and Go commentary. Highlights include Agent Zero's data automation capabilities, Figma-to-code conversion, and the benefits of in-office collaboration for efficient knowledge transfer and AI/ML learning."

--- a/updates/OGIF/25-20240927.md
+++ b/updates/OGIF/25-20240927.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #25 - team & community updates, hybrid culture, product design commentary, AI tooling insights, Golang weekly"
 short_title: "#25 Team updates, Hybrid work, AI insights, Go weekly"
 description: OGIF Office Hours 25 covers the latest insights on hybrid work culture, AI-driven tooling and workflows, Golang compiler optimizations, and AI-enhanced design strategies. Explore discussions on AR/VR trends, voice user interfaces, AI tools for UI/UX, predictive programming, and team demos showcasing AI integrations and Golang performance tweaks.

--- a/updates/OGIF/26-20241004.md
+++ b/updates/OGIF/26-20241004.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #26 - product design commentary, Go Weekly, trading app case study, chatbot evaluations, and announcement for essay assignments"
 short_title: "#26 Design insights, Go tools, Trading app, Chatbots, Essays"
 description: In this Office Hours, Nam Bui shared product design insights on the Sparkle icon in AI and onboarding, Phat covered Go tools Prep and War Zero, and Hoang discussed chatbot evaluations. Anh presented a case study on AI-driven user research for Kafi. Management announced AI essay assignments tied to the year-end trip and performance reviews.

--- a/updates/OGIF/27-20241011.md
+++ b/updates/OGIF/27-20241011.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #27 - Go Weekly, Frontend report Sep, UX guide to prompt with AI, Computing the union of two finite automata"
 short_title: "#27 Go weekly, Frontend, AI UX, Finite Automata"
 description: In OGIF office hour 27, covering presentations on UX Guide to Prompt with AI, computing the union of finite automata, and other topics including Go Weekly and Frontend Report for September.

--- a/updates/OGIF/28-20241018.md
+++ b/updates/OGIF/28-20241018.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #28 - Golang sync.Map, generative AI UX design patterns, Yelp's AI use cases, design patterns in LLM application, and Dify github analyzer"
 short_title: "#28 Go sync.Map, AI UX, Yelp AI, LLM Patterns, Git Analysis"
 description: "OGIF Office Hours #28 covered Go Weekly #16 by Phat on sync.Map concurrency, Nam's Product Commentary #4 on Generative AI UX design patterns, Dat Nguyen's presentation on Yelp's AI use cases including recommendation systems, Hoang's discussion on LLM application design patterns, and Cat's demonstration of a Dify-based Git repository analysis tool."

--- a/updates/OGIF/3-20240419.md
+++ b/updates/OGIF/3-20240419.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #3 - generative AI, tokenomics, and finance talks"
 short_title: "#3 Generative AI, Tokenomics, and Finance Talks"
 description: "Our third office hours community discussion, where we'll cover diverse topics ranging from the current state of the dwarf community and their experiences with devbox, insights on and continuation of liquidity markets, advancements in generative AI technology, to fun events like a lucky draw for icy. The goal is to foster learning by sharing weekly topics suggested through tags, encouraging collaborative growth among our members."

--- a/updates/OGIF/37-20241227.md
+++ b/updates/OGIF/37-20241227.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #37 - AI fine-tuning, data archiving, and datalake scaling with Notion"
 short_title: "#37 AI Fine-tuning, Data archiving, Datalakes"
 description: In OGIF 37, our team dives into AI fine-tuning with an Open AI demo, data archiving for high-traffic apps, and datalake scaling via Notion’s use case. Join us for a session packed with practical insights and collaborative Q&A to boost our technical skills.

--- a/updates/OGIF/38-20250117.md
+++ b/updates/OGIF/38-20250117.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF Office Hours #38 - Erlang automata p2, market report, DOTY, Year end celebrations "
 short_title: "#38 Erlang automata, AI Trends, Year-End Awards"
 description: In OGIF 38, the team explored Erlang automata, AI and fintech market shifts in Southeast Asia, year-end reflections with team awards, and a new hybrid work direction for 2025.

--- a/updates/OGIF/39-20250207.md
+++ b/updates/OGIF/39-20250207.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #39 - frontend updates, database scaling, AI workflow, and macro insights"
 short_title: "#39 Frontend report, DB Scaling, AI Workflow"
 description: In OGIF 39, the team explored React 19 and Deno Deploy updates, database scaling with CI and migrations, Tom’s AI-driven dev workflow, and macro insights on protectionism and globalization trends.

--- a/updates/OGIF/4-20240426.md
+++ b/updates/OGIF/4-20240426.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #4 - DCA, Devbox"
 short_title: "#4 DCA, Devbox"
 description: Our fourth office hours community discussion, from DCA to Devbox topic. The goal is to foster learning by sharing weekly topics suggested through tags, encouraging collaborative growth among our members.

--- a/updates/OGIF/41-20250314.md
+++ b/updates/OGIF/41-20250314.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #41 - ICY-BTC swap, GitHub bot, MCP-DB, Pocket Turing, Recapable, and arbitrage strategy"
 short_title: "#41 ICY-BTC, GitHub bot, MCP-DB, Pocket Turing"
 description: In OGIF 41, the team covered key updates on the ICY-BTC swap, GitHub bot automation, MCP-DB system for agent workflows, and progress on the Pocket Turning and Recapable projects and we also shared insights into funding rate arbitrage strategies.

--- a/updates/OGIF/5-20240503.md
+++ b/updates/OGIF/5-20240503.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #5 - Singapore market report, C4 modelling, how we created Memo's nested sidebar"
 short_title: "#5 Singapore Market Report, C4 Modelling, Memo's Nested Sidebar"
 description: "Our fifth office hours community discussion covers the Singapore market report, C4 modeling, and how we created Memo's nested sidebar. We aim to promote learning and growth within our community by sharing weekly topics, selected through tags, and encouraging collaboration among members."

--- a/updates/OGIF/6-20240510.md
+++ b/updates/OGIF/6-20240510.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #6 - looking at the factory pattern, Erlang state machines, and the trading process"
 short_title: "#6 Factory Pattern, Erlang State Machines, and Trading Process"
 description: "In our sixth community discussion, we'll delve into the Factory pattern, Erlang state machines, and the Trading Process. By sharing weekly topics chosen through tags, we foster a collaborative learning environment for our community to grow."

--- a/updates/OGIF/7-20240517.md
+++ b/updates/OGIF/7-20240517.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #7 - Echelon EXPO, programming patterns, and moonlighting"
 short_title: "#7 Echelon EXPO, Programming patterns, and Moonlighting"
 description: "In our seventh community discussion, we'll discuss about Echelon EXPO; builder, singleton, prototype patterns. By sharing weekly topics chosen through tags, we foster a collaborative learning environment for our community to grow."

--- a/updates/OGIF/9-20240607.md
+++ b/updates/OGIF/9-20240607.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF office hours #9 -  what's next for June and behavior design patterns"
 short_title: "#9 What's next for June and Behavior Design Patterns"
 description: "Join us for our ninth community discussion, where we will be addressing June's key updates and providing an overview of effective behavior design patterns. The discussion will be guided by weekly topics selected through community input, fostering a collaborative learning environment for all participants."

--- a/updates/OGIF/README.md
+++ b/updates/OGIF/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "OGIF - Oh God it's friday"
 description: "OGIF (Oh God It's Friday) is our weekly casual office hours meeting, where team members unwind, share updates, and connect in a relaxed environment at the end of each work week."
 date: 2023-12-11

--- a/updates/arc/README.md
+++ b/updates/arc/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Our takes on the waves that shape us
 short_title: Our bets 🧙‍♂️
 description: Our documented takes on technology waves that shape our direction. Each arc explores breakthrough technologies, explains why they matter, and captures our evolving perspective on building better software.

--- a/updates/arc/final.md
+++ b/updates/arc/final.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: The convergence
 description: How every technology wave we track ultimately serves our four foundational verticals. This is where individual arcs converge into our long-term strategy for empowering innovation.
 date: 2025-01-14

--- a/updates/arc/on-agent.md
+++ b/updates/arc/on-agent.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "On agentic AI"
 description: "Our take on the agentic AI wave and how we're positioning ourselves to do more with less"
 date: 2025-06-15

--- a/updates/arc/thesis/README.md
+++ b/updates/arc/thesis/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Market thesis raw analysis
 description: LLM-generated market thesis documents following our five-step methodology. Think of this as our research workspace where we collect and analyze tech trends before crafting final versions for our arc series.
 date: 2025-01-14

--- a/updates/arc/thesis/agentic-ai.md
+++ b/updates/arc/thesis/agentic-ai.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Agentic AI thesis
 description: A market thesis on Agentic AI, autonomous AI systems that execute complex tasks with reasoning and adaptability. We analyze its potential, map infrastructure and application solutions for startups and Dwarves’ internal operations, and propose top experiment ideas and growth strategies to build expertise, aligning with our strategic verticals.
 date: 2025-06-14

--- a/updates/arc/thesis/algo-stablecoin.md
+++ b/updates/arc/thesis/algo-stablecoin.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Algorithmic Stablecoin thesis
 description: A market thesis on Algorithmic Stablecoin, blockchain-based digital currencies maintaining stability through algorithms. We analyze its potential, map infrastructure and application solutions for startups and Dwarves’ internal operations, and propose top experiment ideas and growth strategies to build expertise, aligning with our strategic verticals.
 date: 2025-06-14

--- a/updates/arc/thesis/bitcoin.md
+++ b/updates/arc/thesis/bitcoin.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Bitcoin thesis
 description: A market thesis on Bitcoin and building with Bitcoin, leveraging its decentralized blockchain for secure, transparent transactions and innovative applications. We analyze its potential, map infrastructure and application solutions for startups and Dwarves’ internal operations, and propose top experiment ideas and growth strategies to build expertise, aligning with our strategic verticals.
 date: 2025-06-14

--- a/updates/arc/thesis/defai.md
+++ b/updates/arc/thesis/defai.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: DeFAI thesis
 description: A market thesis on DeFAI, blending Decentralized Finance with AI (LLMs and Agentic AI) to create trustless, intelligent financial systems. We analyze its potential, map solutions for startups and Dwarves’ internal operations, and propose top experiment ideas and growth strategies to build expertise, aligning with our strategic verticals.
 date: 2025-06-14

--- a/updates/arc/thesis/defi.md
+++ b/updates/arc/thesis/defi.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: DeFi thesis
 description: A market thesis on Decentralized Finance, blockchain-based financial systems enabling trustless, transparent transactions. We analyze its potential, map infrastructure and application solutions for startups and Dwarves’ internal operations, and propose top experiment ideas and growth strategies to build expertise, aligning with our strategic verticals.
 date: 2025-06-14

--- a/updates/arc/thesis/llm.md
+++ b/updates/arc/thesis/llm.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: LLM thesis
 description: A market thesis on Large Language Models, AI systems enabling human-like text generation and reasoning. We analyze their potential, map infrastructure and application solutions for startups and Dwarves’ internal operations, and propose top experiment ideas and growth strategies to build expertise, aligning with our strategic verticals.
 date: 2025-06-14

--- a/updates/arc/thesis/platform-ops.md
+++ b/updates/arc/thesis/platform-ops.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Platform Ops thesis
 description: A market thesis on Platform Ops in the AI era, leveraging AI to automate and optimize infrastructure management and workflows. We analyze its potential, map infrastructure and application solutions for startups and Dwarves’ internal operations, and propose top experiment ideas and growth strategies to build expertise, aligning with our strategic verticals.
 date: 2025-06-14

--- a/updates/arc/thesis/spatial.md
+++ b/updates/arc/thesis/spatial.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Spatial Computing thesis
 description: A market thesis on Spatial Computing, enabling immersive AR/VR experiences and spatial interactions. We analyze its potential, map infrastructure and application solutions for startups and Dwarves’ internal operations, and propose top experiment ideas and growth strategies to build expertise, aligning with our strategic verticals.
 date: 2025-06-14

--- a/updates/arc/thesis/stablecoin.md
+++ b/updates/arc/thesis/stablecoin.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Stablecoin thesis
 description: A market thesis on Stablecoin, blockchain-based digital currencies pegged to stable assets for reliable transactions. We analyze its potential, map infrastructure and application solutions for startups and Dwarves’ internal operations, and propose top experiment ideas and growth strategies to build expertise, aligning with our strategic verticals.
 date: 2025-06-14

--- a/updates/arc/thesis/zkp.md
+++ b/updates/arc/thesis/zkp.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: ZKP thesis
 description: A market thesis on Zero-Knowledge Proofs, cryptographic protocols enabling privacy-preserving verification. We analyze their potential, map solutions for startups and Dwarves’ internal operations, and propose top experiment ideas and growth strategies to build expertise, aligning with our strategic verticals.
 date: 2025-06-13

--- a/updates/build-log/ai-interview-platform-mvp.md
+++ b/updates/build-log/ai-interview-platform-mvp.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Building MVP for AI-driven interview platform
 description: Discover how our two-week MVP harnesses AI-driven, real-time voice processing to streamline interviews, reduce bias, and accelerate hiring success
 date: 2025-03-04

--- a/updates/build-log/ai-powered-monthly-project-reports.md
+++ b/updates/build-log/ai-powered-monthly-project-reports.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Project reports system: a case study"
 description: "An in-depth look at Dwarves' monthly Project Reports system - a lean, efficient system that transforms communication data into actionable intelligence for Operations teams. This case study explores how we orchestrate multiple data streams into comprehensive project insights while maintaining enterprise-grade security and cost efficiency."
 date: 2024-11-14

--- a/updates/build-log/ai-ruby-travel-assistant-chatbot.md
+++ b/updates/build-log/ai-ruby-travel-assistant-chatbot.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: AI-powered Ruby travel assistant
 description: A case study exploring how we built an AI-powered travel assistant using Ruby and AWS Bedrock, demonstrating how choosing the right tools over popular choices led to a more robust and maintainable solution. This study examines our approach to integrating AI capabilities within existing Ruby infrastructure while maintaining enterprise security standards.
 date: 2024-11-21

--- a/updates/build-log/binance-transfer-matching.md
+++ b/updates/build-log/binance-transfer-matching.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Building better Binance transfer tracking
 description: A deep dive into building a robust transfer tracking syste m for Binance accounts, transforming disconnected transaction logs into meaningful fund flow narratives through SQL and data analysis
 date: 2024-11-18

--- a/updates/build-log/bitcoin-alt-performance-tracking.md
+++ b/updates/build-log/bitcoin-alt-performance-tracking.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Tracking Bitcoin-altcoin performance indicators in BTC hedging strategy
 description: This article provides an overview of the importance of tracking Bitcoin-Altcoin performance indicators in a trading strategy known as Hedge, and explains how to visualize this data effectively. It also demonstrates how to render a chart for this strategy using Matplotlib and Seaborn
 date: 2025-01-02

--- a/updates/build-log/brainery/README.md
+++ b/updates/build-log/brainery/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Brainery build log
 short_title: § Brainery 🧠
 description: "The official Brainery build-log. We're detailing our process for creating a 'second brain' designed for continuous learning and insight generation. Covers motivation, system design, and practical data-to-wisdom strategies."

--- a/updates/build-log/brainery/access-brainery.md
+++ b/updates/build-log/brainery/access-brainery.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Access the brainery
 description: This page outlines how developers can connect to and utilize Brainery's extensive knowledge base and AI-driven capabilities. By integrating a straightforward MCP configuration, you can seamlessly access powerful insights directly within your existing development tools and workflows.
 date: 2025-05-06

--- a/updates/build-log/brainery/architecture.md
+++ b/updates/build-log/brainery/architecture.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Architecture
 description: An overview of Brainery's architecture, detailing how it ingests, processes, and transforms data from diverse sources into a dynamic knowledge base.
 date: 2025-05-06

--- a/updates/build-log/brainery/being-human.md
+++ b/updates/build-log/brainery/being-human.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: The point of being human if AI can think?
 description: What’s the point of being human if AI thinks for us? Explore how emotions, creativity, relationships, and purpose make humanity unique in an AI-driven world.
 date: 2025-05-06

--- a/updates/build-log/brainery/data-flow.md
+++ b/updates/build-log/brainery/data-flow.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Data flow in Brainery
 description: How data flows through Brainery's second brain system, from Discord, Memo Blog, and GitHub sources to TimescaleDB via MCP, with an LLM-powered interface for natural language queries.
 date: 2025-05-08

--- a/updates/build-log/brainery/database-design.md
+++ b/updates/build-log/brainery/database-design.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Database design and philosophy
 description: A migration-less, append-only database design using TimescaleDB's hypertables and continuous aggregates to capture observational data and detect emerging patterns through LLM analysis.
 date: 2025-05-08

--- a/updates/build-log/brainery/dikw-pyramid.md
+++ b/updates/build-log/brainery/dikw-pyramid.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Continual learning DIKW pyramid
 description: Exploring the core motivations and principles behind building a personal knowledge management system, a true second brain.
 date: 2025-04-29

--- a/updates/build-log/brainery/human-edge.md
+++ b/updates/build-log/brainery/human-edge.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Human edge in AI world
 description: Discover the human edge in empathy, creativity, intuition, and purpose, where we surpass AI. Learn practical solutions to overcome challenges like AI reliance and isolation to thrive in a tech-driven world.
 date: 2025-05-06

--- a/updates/build-log/brainery/never-forget.md
+++ b/updates/build-log/brainery/never-forget.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Build a brain that never forgets
 description: Explore how we solved the catastrophic forgetting problem in LLMs by building an external knowledge system that mimics learning through context manipulation, without touching the model's parameters.
 date: 2025-05-08

--- a/updates/build-log/brainery/promote-data-to-insight.md
+++ b/updates/build-log/brainery/promote-data-to-insight.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Promoting raw data to insight"
 description: This post explains the multi-stage process of transforming raw data into structured information, and then synthesizing that information into persistent insight and knowledge within a true second brain, leveraging tools like TimescaleDB and LLMs.
 date: 2025-05-07

--- a/updates/build-log/brainery/reading.md
+++ b/updates/build-log/brainery/reading.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Reading after brainery
 description: See how Brainery changes your reading game, helping you learn more and find new things to read, all in a smart loop.
 date: 2025-05-06

--- a/updates/build-log/brainery/rely-on-ai.md
+++ b/updates/build-log/brainery/rely-on-ai.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Does AI make you pretend to know?
 description: Does using AI make you pretend to know? Learn how a second brain helps you truly understand by curating and connecting knowledge, not just querying AI.
 date: 2025-05-06

--- a/updates/build-log/brainery/rfc-mcp-security.md
+++ b/updates/build-log/brainery/rfc-mcp-security.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: MCP authorization over SSE
 description: A Request for Comments (RFC) detailing a comprehensive specification for implementing OAuth 2.1 authorization within the Model Context Protocol (MCP) when using Server-Sent Events (SSE) as the transport mechanism, ensuring vendor-neutral security for AI-to-tool communication.
 date: 2025-05-08

--- a/updates/build-log/brainery/rfc-semantic-reasoning.md
+++ b/updates/build-log/brainery/rfc-semantic-reasoning.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Append-only concept embedding log
 description: RFC proposing a novel approach to track concept evolution using TimescaleDB with pgvector/pgvectorscale, enabling historical semantic analysis and preventing catastrophic forgetting in continual learning systems.
 date: 2025-05-08

--- a/updates/build-log/brainery/use-cases.md
+++ b/updates/build-log/brainery/use-cases.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Building use-cases
 description: Building systems that actually learn and get smarter over time is hard, facing challenges with traditional databases and LLMs. This post outlines an approach to building a true second brain that continuously learns, generates insight, and remembers it through an append-only log and flexible data structures.
 date: 2025-05-07

--- a/updates/build-log/brainery/why-build-second-brain.md
+++ b/updates/build-log/brainery/why-build-second-brain.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Why build a second brain when AI can think for us?
 description: Discover why a personal second brain is still valuable in the AI era. Learn how it curates knowledge, sparks creativity, and complements LLMs for deeper insights.
 date: 2025-05-06

--- a/updates/build-log/building-an-ai-powered-agent-system-with-openrouter-sdk-and-web3-technologies.md
+++ b/updates/build-log/building-an-ai-powered-agent-system-with-openrouter-sdk-and-web3-technologies.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Building an AI-powered agent system with OpenRouter SDK and Web3 technologies
 description: Explore the system design behind scalable AI agents, featuring modular architecture, streaming responses, and automated task scheduling for social platforms.
 date: 2025-04-29

--- a/updates/build-log/building-chatbot-agent-for-project-management-tool.md
+++ b/updates/build-log/building-chatbot-agent-for-project-management-tool.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Building chatbot agent to streamline project management
 description: A technical case study detailing the implementation of an AI chatbot agent in a project management platform. Learn how the team leveraged LangChain, LangGraph, and GPT-4 to build a multi-agent system using the supervisor-worker pattern.
 date: 2024-11-21

--- a/updates/build-log/centralized-monitoring-setup-for-trading-platform.md
+++ b/updates/build-log/centralized-monitoring-setup-for-trading-platform.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Setup centralized monitoring system for Hedge Foundation trading platform
 description: A technical case study for implementing centralized monitoring for a trading platform using Grafana and Prometheus, focusing on real-time alerts, data integrity, and resource optimization to prevent financial losses.
 date: 2024-11-21

--- a/updates/build-log/company/README.md
+++ b/updates/build-log/company/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Build a research-first tech company
 short_title: § Research-first tech company 🧪
 description: Guide to building a research-first tech company and community by turning ideas into impact, building a trusted brand, and fostering growth.

--- a/updates/build-log/company/brand.md
+++ b/updates/build-log/company/brand.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Build a trusted brand: Be known for great work"
 description: Brand value compounds over time through positive footprints and inbound attraction. Learn how to build a brand that people love to be associated with and that becomes your most valuable long-term asset.
 date: 2025-05-16

--- a/updates/build-log/company/community.md
+++ b/updates/build-log/company/community.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Grow a community: Events, forums, or online groups"
 description: Building a thriving community around your expertise through events, forums, and online groups. Learn how community becomes your strongest moat and growth engine.
 date: 2025-05-16

--- a/updates/build-log/company/company.md
+++ b/updates/build-log/company/company.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Company: Brand value + Trade secrets"
 description: Understanding how companies create lasting value through the combination of brand reputation and proprietary knowledge. Learn why both elements are essential for sustainable competitive advantage.
 date: 2025-05-16

--- a/updates/build-log/company/funding.md
+++ b/updates/build-log/company/funding.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Get money to grow: Investors, grants, or partners"
 description: Strategic approaches to funding growth through investors, grants, and partnerships. Learn how to choose the right funding path and maintain control while scaling your research-first company.
 date: 2025-05-16

--- a/updates/build-log/company/identity.md
+++ b/updates/build-log/company/identity.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Know your mission & what makes you special"
 description: Defining your company's unique identity and mission creates clarity for decisions and attracts the right people. Learn how to articulate what makes you different and why it matters.
 date: 2025-05-16

--- a/updates/build-log/company/knowledge-hub.md
+++ b/updates/build-log/company/knowledge-hub.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Build a central hub for knowledge & ops"
 description: Creating a centralized knowledge and operations hub that captures institutional memory and streamlines processes. Learn how to build systems that preserve wisdom and accelerate decision-making.
 date: 2025-05-16

--- a/updates/build-log/company/profitable.md
+++ b/updates/build-log/company/profitable.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Profitable: make more money than you spend"
 description: Explains the core concept of profitability for a company in simple terms, revenue must exceed costs for sustainable growth.
 date: 2025-05-16

--- a/updates/build-log/company/research-consulting.md
+++ b/updates/build-log/company/research-consulting.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Start with a strong research team"
 description: Building a research-first consulting team that stays sharp on emerging tech and opens new opportunities. Learn how to find and build the right mix of curious minds and practical problem-solvers.
 date: 2025-05-16

--- a/updates/build-log/company/research-value.md
+++ b/updates/build-log/company/research-value.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Research to Value: Turn ideas into products or impact"
 description: Explains how connecting cutting-edge research with practical application drives innovation, provides solutions, and creates impact.
 date: 2025-05-16

--- a/updates/build-log/company/resilience.md
+++ b/updates/build-log/company/resilience.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Stay resilient: Pass the test of time"
 description: Building company resilience to weather storms and emerge stronger. Learn how to prepare for inevitable challenges and develop the mindset and systems needed to thrive through any crisis.
 date: 2025-05-16

--- a/updates/build-log/company/scaling.md
+++ b/updates/build-log/company/scaling.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Scale smart: Grow big but stay research-first"
 description: Strategic approaches to scaling while preserving research-first culture and capabilities. Learn how to grow without losing what made you special in the first place.
 date: 2025-05-16

--- a/updates/build-log/company/sharing-ideas.md
+++ b/updates/build-log/company/sharing-ideas.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Share your ideas: Create research, posts, or tools"
 description: Building reputation and community through sharing research, writing insightful posts, and creating useful tools. Learn how knowledge sharing becomes a competitive advantage and growth engine.
 date: 2025-05-16

--- a/updates/build-log/company/sustainable.md
+++ b/updates/build-log/company/sustainable.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Sustainable: Stay strong over time"
 description: Discusses how to build a company that thrives long-term through resilience, community, and continuous innovation.
 date: 2025-05-16

--- a/updates/build-log/company/talent.md
+++ b/updates/build-log/company/talent.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Attract & keep talented people"
 description: Treating team members as talent through recognition and care while actively seeking great people. Learn how leaders can become talent magnets and build teams that want to stay and grow.
 date: 2025-05-16

--- a/updates/build-log/company/tough-times.md
+++ b/updates/build-log/company/tough-times.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Handle tough times: Tech shifts, money issues"
 description: Practical strategies for navigating difficult periods including technology disruptions and financial challenges. Learn how to survive setbacks and emerge stronger from adversity.
 date: 2025-05-16

--- a/updates/build-log/create-slides-with-overleaf.md
+++ b/updates/build-log/create-slides-with-overleaf.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Create slides with Overleaf and ChatGPT
 description: This article shares a workflow for making slide decks with Overleaf and ChatGPT. It solves issues like slow content creation using ChatGPT and formats with Overleaf’s themes. It includes examples, tips, and a Dify automation for engineers.
 date: 2025-03-20

--- a/updates/build-log/crypto-market-outperform-chart-rendering.md
+++ b/updates/build-log/crypto-market-outperform-chart-rendering.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Visualizing crypto market performance: BTC-Alt dynamic indicators in Golang"
 description: Implementing a Golang-based visualization for crypto market performance indicators, focusing on Bitcoin vs Altcoin dynamics and trading strategy effectiveness through interactive charts and data analysis
 date: 2024-11-18

--- a/updates/build-log/data-archive-and-recovery.md
+++ b/updates/build-log/data-archive-and-recovery.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Building a data archive and recovery strategy for high-volume trading system
 description: A guide to implementing data archival and recovery strategies for high-volume transactional application.
 date: 2024-12-13

--- a/updates/build-log/database-hardening-for-trading-platform.md
+++ b/updates/build-log/database-hardening-for-trading-platform.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: 'Database hardening for a trading platform'
 description: 'Discover how a trading platform mitigated database access risks, enhanced security, and ensured data integrity through role-based access control, network isolation, MFA, and robust logging. Learn about the strategies and tools, like Teleport, that transformed operational efficiency and reinforced client trust.'
 date: 2025-01-02T00:00:00.000Z

--- a/updates/build-log/discord-mcp-bot/README.md
+++ b/updates/build-log/discord-mcp-bot/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Build a MCP client for Discord
 description: null
 date: 2025-05-22

--- a/updates/build-log/enhancing-cryptocurrency-transfer-logger.md
+++ b/updates/build-log/enhancing-cryptocurrency-transfer-logger.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Transfer mapping: enhancing loggers for better transparency"
 description: A comprehensive guide on improving cryptocurrency transfer logging systems to provide better transparency and traceability for users and developers.
 date: 2024-11-18

--- a/updates/build-log/implement-binance-future-pnl-analysis-page.md
+++ b/updates/build-log/implement-binance-future-pnl-analysis-page.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Implement Binance Futures PNL analysis page by Phoenix LiveView
 description: Implementing Binance Futures PNL Analysis page with Phoenix LiveView to optimize development efficiency. This approach reduces the need for separate frontend and backend resources while enabling faster real-time data updates through WebSocket connections and server-side rendering.
 date: 2025-01-15

--- a/updates/build-log/memo/README.md
+++ b/updates/build-log/memo/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Memo build log
 short_title: § Memo 📝
 description: "Memo is our knowledge base, capturing collective learnings and activities. This build log documents the technical journey of creating and maintaining the platform."

--- a/updates/build-log/memo/build-pipeline.md
+++ b/updates/build-log/memo/build-pipeline.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: The Memo build and content quality pipeline
 description: "Understand the automated processes and tools that transform Markdown content into the published Memo website, ensuring content quality and consistency."
 date: 2025-05-20

--- a/updates/build-log/memo/deployment.md
+++ b/updates/build-log/memo/deployment.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Automating static site deployment
 description: "Learn about the automated deployment workflow for the Memo platform, powered by GitHub Actions for seamless publishing and integration."
 date: 2025-05-20

--- a/updates/build-log/memo/duckdb-as-intermediary-storage.md
+++ b/updates/build-log/memo/duckdb-as-intermediary-storage.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: DuckDB as intermediary storage
 description: "Learn how we use DuckDB as a flexible and efficient intermediary storage solution in the Memo content pipeline."
 date: 2025-05-20

--- a/updates/build-log/memo/markdown-lint.md
+++ b/updates/build-log/memo/markdown-lint.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Markdown lint
 description: "An exploration of how Dwarves Foundation automates Markdown quality using modular linting, generative formatting, and cross-repo CI/CD integration."
 date: 2025-08-13

--- a/updates/build-log/memo/memo-architecture.md
+++ b/updates/build-log/memo/memo-architecture.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Memo architecture
 description: "Technical architecture of the Memo platform: components, data flow, and technologies for processing, storing, and rendering content."
 date: 2025-05-20

--- a/updates/build-log/memo/monitoring.md
+++ b/updates/build-log/memo/monitoring.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Monitoring
 description: "Learn about our dual approach to monitoring at memo.d.foundation, combining synthetic and instrumental monitoring to ensure system health and community engagement."
 date: 2025-07-05

--- a/updates/build-log/memo/multi-git-submodules.md
+++ b/updates/build-log/memo/multi-git-submodules.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Managing content with Git submodules
 description: "Learn how we use Git submodules to link and manage multiple content repositories in the Memo platform."
 date: 2025-05-20

--- a/updates/build-log/memo/onchain-permanent-storage.md
+++ b/updates/build-log/memo/onchain-permanent-storage.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Onchain permanent storage
 description: "Explore how the Memo platform utilizes Arweave for permanent content storage and blockchain integration for NFT minting."
 date: 2025-05-20

--- a/updates/build-log/memo/redirect-and-alias.md
+++ b/updates/build-log/memo/redirect-and-alias.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Redirect and Alias
 description: 'Implementing a URL redirect system for NextJS static memo pages to create SEO-friendly, shareable URLs while maintaining backward compatibility.'
 date: 2025-05-28

--- a/updates/build-log/memo/single-makefile.md
+++ b/updates/build-log/memo/single-makefile.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Streamline development with a single Makefile
 description: "Discover how a unified Makefile simplifies the development workflow for the Memo platform, standardizing toolchain and speeding up common tasks."
 date: 2025-05-21

--- a/updates/build-log/memo/static-site-by-choice.md
+++ b/updates/build-log/memo/static-site-by-choice.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Build a static site by choice
 description: "Learn why we chose a static site architecture for the Memo platform and how Next.js facilitates dynamic page rendering and content processing."
 date: 2025-05-20

--- a/updates/build-log/migrate-normal-table-to-timescale-table.md
+++ b/updates/build-log/migrate-normal-table-to-timescale-table.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Migrate regular tables into TimescaleDB hypertables to improve query performance
 description: How do we migrate normal table to timescale table to optimized data storage
 date: 2025-01-15

--- a/updates/build-log/monitoring/README.md
+++ b/updates/build-log/monitoring/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: How we build our monitoring system
 short_title: § Monitoring 
 description: A guide to building effective monitoring systems, covering components, implementation, metrics, correlation, and scaling strategies for tech teams.

--- a/updates/build-log/monitoring/approach-to-build.md
+++ b/updates/build-log/monitoring/approach-to-build.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Approach to building monitoring
 description: A practical guide to building monitoring systems that actually work. We share our approach to making smart decisions about what to monitor, how to collect data, and when to add complexity.
 authors:

--- a/updates/build-log/monitoring/best-practices.md
+++ b/updates/build-log/monitoring/best-practices.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Monitoring best practices
 description: Hard-learned lessons from building monitoring systems in production. We share common mistakes to avoid and practical strategies for growing your monitoring capabilities over time.
 authors:

--- a/updates/build-log/monitoring/components.md
+++ b/updates/build-log/monitoring/components.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Monitoring components
 description: Understanding the building blocks of effective system monitoring. We break down synthetic monitoring, instrumentation, logging, and tracing to help you build observability into your applications.
 authors:

--- a/updates/build-log/monitoring/correlation-layer.md
+++ b/updates/build-log/monitoring/correlation-layer.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Correlation layer
 description: How to connect metrics, logs, and traces for faster debugging. We explain the investigation flow and practical strategies for correlating data across your monitoring stack.
 authors:

--- a/updates/build-log/monitoring/implementation-guide.md
+++ b/updates/build-log/monitoring/implementation-guide.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Implementation guide for monitoring systems
 description: Practical implementation guidance for setting up comprehensive monitoring across all aspects of your system - from infrastructure to code quality and team performance.
 authors:

--- a/updates/build-log/monitoring/metrics-planning-prompt.md
+++ b/updates/build-log/monitoring/metrics-planning-prompt.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: LLM prompt for metrics planning
 description: A comprehensive prompt template to get tailored metrics recommendations for any system. Use this with ChatGPT, Claude, or other LLMs to design monitoring that actually matters.
 authors:

--- a/updates/build-log/monitoring/metrics.md
+++ b/updates/build-log/monitoring/metrics.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Which metrics actually matter
 description: A practical guide to choosing the right metrics for system health monitoring. We cut through the noise to focus on metrics that directly impact your users and business.
 authors:

--- a/updates/build-log/monitoring/request-and-trace.md
+++ b/updates/build-log/monitoring/request-and-trace.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Trace IDs and request IDs that work
 description: Understanding when to use trace_id versus request_id, and how to implement correlation that actually helps during incidents. We explore practical patterns for different system scales.
 authors:

--- a/updates/build-log/monitoring/scale.md
+++ b/updates/build-log/monitoring/scale.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Does monitoring scale with your system?
 description: Understanding when to invest in comprehensive monitoring versus keeping it simple. We explore how system scale, user impact, and team resources should drive your monitoring decisions.
 authors:

--- a/updates/build-log/monitoring/synthetic-only.md
+++ b/updates/build-log/monitoring/synthetic-only.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Can you rely mostly on synthetic monitoring?
 description: Exploring when synthetic monitoring alone makes sense and how to maximize its value when you can't instrument your systems or need to keep teams separate.
 authors:

--- a/updates/build-log/optimize-init-load-time-for-trading-platform.md
+++ b/updates/build-log/optimize-init-load-time-for-trading-platform.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: 'Optimizing initial load time for a trading platform'
 description: 'Discover the technical strategies behind optimizing a Binance trading platform, reducing initial load times to under 1 second for enhanced trader productivity.'
 date: 2025-03-12T00:00:00.000Z

--- a/updates/build-log/optimizing-ui-for-effective-investment-experience.md
+++ b/updates/build-log/optimizing-ui-for-effective-investment-experience.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Hedge Foundation - optimizing UI for effective investment experience
 description: Designing the UI for a blockchain-based hedge fund platform like Hedge Foundation is not just about creating a visually appealing interface. The real challenge lies in ensuring that complex financial data is presented in an intuitive, understandable way that helps users make quick investment decisions. Optimizing the UI plays a crucial role in allowing investors to access accurate data without feeling overwhelmed by excessive information.
 date: 2025-02-25

--- a/updates/build-log/persist-history-using-data-snapshot-pattern.md
+++ b/updates/build-log/persist-history-using-data-snapshot-pattern.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Implementing data snapshot pattern to persist historical data
 description: A technical exploration of implementing the data snapshot pattern for efficient historical data persistence
 date: 2024-12-11

--- a/updates/build-log/playbook/README.md
+++ b/updates/build-log/playbook/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "MCP playbook documentation"
 short_title: "📚 MCP playbook"
 description: "An index and introduction to the mcp-playbook server documentation series, covering its purpose, setup, and operational flows. This collection helps you understand and leverage the tools for systematic knowledge management."

--- a/updates/build-log/playbook/code-flow.md
+++ b/updates/build-log/playbook/code-flow.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "MCP playbook code flow"
 description: "A detailed look into the mcp-playbook's internal code flow, data handling for chat logs and prompts, and interactions with GitHub repositories like prompt-db and prompt-log. This technical deep-dive helps developers understand the implementation details for debugging and extending functionality."
 date: 2025-05-13

--- a/updates/build-log/playbook/data-flow.md
+++ b/updates/build-log/playbook/data-flow.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "MCP playbook data flow"
 description: "How data flows through the MCP playbook server, from MCP client requests to tool execution and interactions with the file system and GitHub. This overview helps you understand the architecture and system interactions for better troubleshooting and development."
 date: 2025-05-13

--- a/updates/build-log/playbook/motivation.md
+++ b/updates/build-log/playbook/motivation.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "AI knowledge automation"
 description: "Exploring the motivations behind the MCP Playbook, its role in establishing a dynamic runbook, and new patterns for capturing AI-generated knowledge like chat logs and prompts."
 date: 2025-05-13

--- a/updates/build-log/playbook/setup.md
+++ b/updates/build-log/playbook/setup.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "MCP playbook setup"
 description: "A step-by-step tutorial on configuring and running the mcp-playbook server, including GitHub token creation and using npx. This guide helps you get started with automated documentation and knowledge management tools."
 date: 2025-05-13

--- a/updates/build-log/publication/README.md
+++ b/updates/build-log/publication/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Content publication tooling
 description: Exploring the tooling and process used by Dwarves to transform engineering outputs into published content (videos, blogs, podcasts, etc.) for our community.
 date: 2025-05-25

--- a/updates/build-log/publication/building-data-pipeline-ogif-transcriber.md
+++ b/updates/build-log/publication/building-data-pipeline-ogif-transcriber.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Building data pipeline for OGIF transcriber
 description: A technical case study of creating an automated system that downloads videos, processes audio, and generates transcripts using AI services like Groq and OpenAI.
 date: 2024-11-21

--- a/updates/build-log/publication/compose-video.md
+++ b/updates/build-log/publication/compose-video.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Composing the Dwarves video pipeline
 description: "A behind-the-scenes look at how we built our video pipeline for long-form explainers and short-form content, from script to screen, with AI in the loop."
 date: 2025-07-10

--- a/updates/build-log/reconstructing_trading_pnl_data_pipeline_approach.md
+++ b/updates/build-log/reconstructing_trading_pnl_data_pipeline_approach.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Reconstructing historical trading PnL: a data pipeline approach"
 description: A detailed look at how we rebuilt historical trading PnL data through an efficient data pipeline approach, transforming a complex problem into a maintainable solution.
 date: 2024-11-18

--- a/updates/build-log/service_monitoring_with_upptime.md
+++ b/updates/build-log/service_monitoring_with_upptime.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Secure and transparent uptime monitoring with Upptime and GitHub secrets
 description: Discover how Dwarves Foundation uses Upptime and GitHub Actions for transparent public uptime monitoring while securely keeping tabs on internal services.
 date: 2025-03-31

--- a/updates/build-log/vibe-coding/README.md
+++ b/updates/build-log/vibe-coding/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: § How to vibe
 description: null
 authors:

--- a/updates/build-log/vibe-coding/how-to-be-a-good-planner.md
+++ b/updates/build-log/vibe-coding/how-to-be-a-good-planner.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: How to be a good planner
 description: A guide to effective planning in software development, winning with AI-assisted workflows.
 date: 2025-05-27

--- a/updates/build-log/vibe-coding/prompt-db.md
+++ b/updates/build-log/vibe-coding/prompt-db.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Prompts
 description: null
 date: 2025-05-14

--- a/updates/changelog/2020-01-15-five.md
+++ b/updates/changelog/2020-01-15-five.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Five years of building things right
 description: From a small software studio in Saigon to a global company spanning three continents. Here's how we built something that matters in an industry that often doesn't respect the craft.
 date: 2020-01-15

--- a/updates/changelog/2021-06-10-dwarves-updates.md
+++ b/updates/changelog/2021-06-10-dwarves-updates.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Dwarves updates
 description: Hi, this is Han, the CEO of Dwarves Foundation. This month the Dwarves score 40th client that we have the honor to serve. And for that, we decide to launch the Dwarves updates.
 date: 2021-06-10

--- a/updates/changelog/2021-07-11-dalat-office.md
+++ b/updates/changelog/2021-07-11-dalat-office.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Da Lat office
 description: "It's Han and the Dwarves team again. Since June 2020, we've been planning on a new office/studio in Da Lat."
 date: 2021-07-11

--- a/updates/changelog/2021-08-23-project-compliance.md
+++ b/updates/changelog/2021-08-23-project-compliance.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Project compliance
 description: This email is the third month we share about our journey to Software Craftsmanship.
 date: 2021-08-23

--- a/updates/changelog/2021-09-29-engineer-performance-review.md
+++ b/updates/changelog/2021-09-29-engineer-performance-review.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Engineer performance review
 description: "Here's another update from Dwarves for you. Throughout September, we have completed our bi-annual performance review."
 date: 2021-09-29

--- a/updates/changelog/2021-10-31-path-to-growth.md
+++ b/updates/changelog/2021-10-31-path-to-growth.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: The path to growth at Dwarves
 description: "It's Han and Nikki from Team Dwarves. We're here with the fifth edition of our Dwarves Updates. October has been a wild ride for us as a company. Most of our effort was spent on rethinking growth paths for our engineers."
 date: 2021-10-31

--- a/updates/changelog/2021-12-01-engineering-org-structure.md
+++ b/updates/changelog/2021-12-01-engineering-org-structure.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Engineering organizational structure
 description: "It's Han and Nikki from Team Dwarves. We're almost at the end of this year. While we know everyone is busy wrapping up 2021, we hope you're taking care of yourself and staying safe."
 date: 2021-12-01

--- a/updates/changelog/2021-12-30-2021-in-review.md
+++ b/updates/changelog/2021-12-30-2021-in-review.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "It's a wrap: 2021 in review"
 description: Hey, it’s Han and Nikki in your inbox again. On behalf of the entire Dwarves team, happy 2022!
 date: 2021-12-30

--- a/updates/changelog/2022-03-31-hiring-stages.md
+++ b/updates/changelog/2022-03-31-hiring-stages.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: The stages of hiring at Dwarves
 description: In today’s edition, job interviews need a makeover, the 4 stages of hiring at Dwarves, Dwarves apprenticeship 2022, other talking points
 date: 2022-03-31

--- a/updates/changelog/2022-06-26-blockchain-and-data.md
+++ b/updates/changelog/2022-06-26-blockchain-and-data.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: The future is blockchain and data
 description: Hey, it’s Han and Nikki in your inbox again.
 date: 2022-06-26

--- a/updates/changelog/2022-08-26-the-next-leading-chairs.md
+++ b/updates/changelog/2022-08-26-the-next-leading-chairs.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: The next leading chairs
 description: We like the idea of labeling teams by what they deliver. Hence, the next chapter of Dwarves will be based on five angles.
 date: 2022-08-26

--- a/updates/changelog/2023-09-12-growth-stages.md
+++ b/updates/changelog/2023-09-12-growth-stages.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: The stage of growth at Dwarves
 description: In this update, we are excited to share the real journey of growth and transformation that our team has embarked upon, as we continue to strive to become a more skilled and knowledgable software team.
 date: 2023-09-12

--- a/updates/changelog/2024-09-13-dwarve-updates-ai-llm.md
+++ b/updates/changelog/2024-09-13-dwarve-updates-ai-llm.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: The stage of AI and LLM at Dwarves
 description: "Here's another update from Dwarves for you. We are excited to share the real journey of growth and transformation since AI and LLM have been on our radar for quite a long time."
 date: 2024-09-13

--- a/updates/changelog/2024-10-25-knowledge-base.md
+++ b/updates/changelog/2024-10-25-knowledge-base.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Build your knowledge base
 description: In an age where Large Language Models like ChatGPT offer instant access to a universe of information, it raises the question, does our own personal knowledge base still hold any value, and is building a personal knowledge base still a legitimate thing to do?
 date: 2024-10-25

--- a/updates/changelog/README.md
+++ b/updates/changelog/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Dwarves updates
 description: null
 date: 2024-03-12

--- a/updates/digest/01-first-release-of-dwarves-digest.md
+++ b/updates/digest/01-first-release-of-dwarves-digest.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#01 - First release of Dwarves Digest"
 description: A collection of company updates, including Canada branch registration, employee stock ownership plan.
 date: 2019-11-30

--- a/updates/digest/02-environment-shape-up.md
+++ b/updates/digest/02-environment-shape-up.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#02 - Environment Shape Up"
 description: Updates on company culture, year-end bonus, business partnerships
 date: 2019-12-07

--- a/updates/digest/03-planning-for-year-end-party.md
+++ b/updates/digest/03-planning-for-year-end-party.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#03 - Planning for Year-End Party"
 description: Stay updated on Dwarves Foundation’s year-end party, apprenticeship program, insurance policies, tech workshops, and ongoing training classes to boost team skills and benefits.
 date: 2019-12-14

--- a/updates/digest/04-introduce-to-hidden-bar.md
+++ b/updates/digest/04-introduce-to-hidden-bar.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#04 - Introduce to Hidden Bar"
 description: Hidden Bar is a MacOS app that hides unwanted menu bar items for a clean, minimal desktop, praised by LifeHacker and HackerNews.
 date: 2019-12-21

--- a/updates/digest/05-last-engineering-meeting-of-the-year.md
+++ b/updates/digest/05-last-engineering-meeting-of-the-year.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#05 - Last engineering meeting of the year!"
 description: "Discover the latest engineering meeting highlights, team updates, jacket design sneak peek, and plans for The Dwarves' 5th anniversary retreat and awards."
 date: 2019-12-28

--- a/updates/digest/06-you-re-invited-to-dwarves-foundation-5th-anniversary.md
+++ b/updates/digest/06-you-re-invited-to-dwarves-foundation-5th-anniversary.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#06 - You're invited to Dwarves Foundation 5th anniversary"
 description: Celebrate Dwarves Foundation’s 5th anniversary with team updates, office cleaning plans, and a blog on Readme Driven Development to improve work processes.
 date: 2020-01-04

--- a/updates/digest/07-the-dwarves-turns-5.md
+++ b/updates/digest/07-the-dwarves-turns-5.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#07 - The Dwarves Turns 5 🎂"
 description: Celebrate the 5th anniversary of Dwarves Foundation with team retreats, new benefits, Engineering discussions, a Hall of Fame website, and exciting new hires.
 date: 2020-01-11

--- a/updates/digest/08-the-1st-report-of-tech-radar.md
+++ b/updates/digest/08-the-1st-report-of-tech-radar.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#08 - The 1st report of Tech Radar"
 description: Discover the first Tech Radar report highlighting engineering projects, company handbook updates, bonuses, English class support, insurance, and remote work during Lunar New Year.
 date: 2020-01-18

--- a/updates/digest/09-grab-your-next-payment-with-transferwise.md
+++ b/updates/digest/09-grab-your-next-payment-with-transferwise.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#09 - Grab your next payment with TransferWise"
 description: Learn how to register a TransferWise account for secure monthly payments and get updates on remote work, English courses, and Tech Radar progress in the team.
 date: 2020-02-01

--- a/updates/digest/1-what-do-you-stand-for.md
+++ b/updates/digest/1-what-do-you-stand-for.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly Digest #1: What do you stand for?"
 short_title: "#1 What do you stand for?"
 description: Our Discord crew is buzzing with energy after our last Friday community call, with folks sharing snapshots of their workspaces, Anna shared the movie quote and catch-up with peeps at lobby, random channels.

--- a/updates/digest/10-from-lean-to-learner.md
+++ b/updates/digest/10-from-lean-to-learner.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly digest #10: From lean to learner"
 short_title: "#10 From lean to learner"
 description: "Double digits, I can't believe we've reached our 10th digest! It's been quite a journey putting together each edition and a blast creating these for you. When we talk about memo, we're highlighting an essential part of our learning culture. We’ve just noted a few updates for the cycle ahead. Now, let's dive into this round-up."

--- a/updates/digest/10-the-3rd-milestone-of-tech-radars.md
+++ b/updates/digest/10-the-3rd-milestone-of-tech-radars.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#10 - The 3rd milestone of tech radars"
 description: Discover the latest Tech Radar milestone updates, apprenticeship program timeline, team bonding survey, and welcome new front-end and back-end engineers to the team.
 date: 2020-02-08

--- a/updates/digest/100-dwarves-changelog-the-100th.md
+++ b/updates/digest/100-dwarves-changelog-the-100th.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#100 - Dwarves Changelog the 100th"
 description: Discover the latest team updates on office redesign, tech sessions covering k8s and real-time web apps, and plans for the November all-hands meeting.
 date: 2021-11-20

--- a/updates/digest/101-danang-office.md
+++ b/updates/digest/101-danang-office.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#101 - DaNang Office"
 description: Join the November All-hands Meeting on December 2 to hear project updates, team news, and learn about the new Da Nang office and job opportunities.
 date: 2021-11-27

--- a/updates/digest/102-november-all-hands-sum-up.md
+++ b/updates/digest/102-november-all-hands-sum-up.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#102 - November All-hands Sum up"
 description: Our team focuses on blockchain deals, expanding with new experts, upgrading hiring processes, and hosting tech meetups while boosting collaboration through training and Discord.
 date: 2021-12-04

--- a/updates/digest/103-in-dwarves-last-week.md
+++ b/updates/digest/103-in-dwarves-last-week.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#103 - In Dwarves last week"
 description: Discover the latest updates on blockchain learning, Solana platform sessions, and community growth in Dwarves Discord with upcoming DOTY 2021 voting news.
 date: 2021-12-11

--- a/updates/digest/104-vote-for-your-dwarves.md
+++ b/updates/digest/104-vote-for-your-dwarves.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#104 - Vote for your Dwarves"
 description: "Get the latest updates on Dwarves' New Year holiday schedule, voting for Dwarves of The Year 2021, office returns, and Da Lat design plans."
 date: 2021-12-18

--- a/updates/digest/105-ready-to-close-2021.md
+++ b/updates/digest/105-ready-to-close-2021.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#105 - Ready to Close 2021?"
 description: "Join our December All-hands meeting to review this year's changes, vote for DOTY, and catch the Team Showcase highlights on YouTube."
 date: 2021-12-25

--- a/updates/digest/106-how-was-your-holiday.md
+++ b/updates/digest/106-how-was-your-holiday.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#106 - How was your holiday?"
 description: Join our January 7 All-hands meeting to celebrate 2021 achievements, announce DOTY winners, and welcome new members to our growing tech community.
 date: 2021-12-31

--- a/updates/digest/107-lunar-new-year-holiday-schedule.md
+++ b/updates/digest/107-lunar-new-year-holiday-schedule.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#107 - Lunar New Year Holiday Schedule"
 description: "Review our 2021 achievements, learn about our Lunar New Year holiday schedule, and catch the Software Modeling study group's design system presentation for a streaming startup."
 date: 2022-01-08

--- a/updates/digest/108-dwarves-youtube-is-back.md
+++ b/updates/digest/108-dwarves-youtube-is-back.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#108 - Dwarves Youtube is back"
 description: Get updates on our Lunar New Year gift set delivery, new team members, recruitment, and explore our revamped Dwarves YouTube channel for knowledge training.
 date: 2022-01-21

--- a/updates/digest/109-back-to-work-1-way-flight-ticket.md
+++ b/updates/digest/109-back-to-work-1-way-flight-ticket.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#109 - Back to work & 1-way flight Ticket"
 description: "Start your work year energized after Lunar New Year with one-way flight tickets and catch Agile Software Development insights from Tuan Tran's presentation online."
 date: 2022-02-08

--- a/updates/digest/11-come-grow-with-us.md
+++ b/updates/digest/11-come-grow-with-us.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly digest #11: Come grow with us"
 short_title: "#11 Come grow with us"
 description: "Things are always cooking on our Discord. So grab a virtual seat at our table, pour yourself a cup of something tasty, and read the digest. If you're reading this, why not pop into the woodland and say hello? We'd love to meet you."

--- a/updates/digest/11-take-care-of-your-beloved-now-or-get-sml-later.md
+++ b/updates/digest/11-take-care-of-your-beloved-now-or-get-sml-later.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#11 - Take care of your beloved now or get sml later"
 description: Stay informed on COVID-19 updates, office surveys, apprenticeship programs, and Tech Radar R&D progress to keep your workplace safe and innovative.
 date: 2020-02-15

--- a/updates/digest/110-health-insurance-renewal.md
+++ b/updates/digest/110-health-insurance-renewal.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#110 - Health Insurance Renewal"
 description: Learn about Bao Viet health insurance renewal, support ticket system, skip-level meetings, and a Grafana Loki tutorial to improve your team experience and benefits.
 date: 2022-02-14

--- a/updates/digest/111-on-the-move-of-hiring.md
+++ b/updates/digest/111-on-the-move-of-hiring.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#111 - On the move of Hiring "
 description: Get updates on salary adjustments, new apprenticeship and tech events, team growth, and a backend engineering talk for the NFT marketplace at Dwarves.
 date: 2022-02-18

--- a/updates/digest/112-going-crypto-native.md
+++ b/updates/digest/112-going-crypto-native.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#112 - Going crypto-native"
 description: Join our crypto-native firm to receive monthly salaries in BUSD/USDT and stay updated on team news, projects, and hiring plans in our February All Hands Meeting.
 date: 2022-02-28

--- a/updates/digest/113-dwarves-sponsor.md
+++ b/updates/digest/113-dwarves-sponsor.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#113 - Dwarves Sponsor"
 description: Join Dwarves Brainery to share knowledge on topics like C compilers, blockchain, and monorepos while earning sponsorship and enjoying fun Discord events.
 date: 2022-03-12

--- a/updates/digest/114-growing-the-brainery.md
+++ b/updates/digest/114-growing-the-brainery.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#114 - Growing the Brainery"
 description: Discover March Brainery updates, DF Apprenticeship 2022 registration, Women’s Day voting, and new merchandise ideas to support learning and community engagement.
 date: 2022-03-21

--- a/updates/digest/115-launching-apprenticeship.md
+++ b/updates/digest/115-launching-apprenticeship.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#115 - Launching Apprenticeship"
 description: Join the Dwarves Apprenticeship Program and Career Fair with coding challenges, mock interviews, and learn about serverless architecture from expert presentations.
 date: 2022-03-26

--- a/updates/digest/116-wrapping-up-march.md
+++ b/updates/digest/116-wrapping-up-march.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#116 - Wrapping up March"
 description: Discover our March update on project deployment, Dwarves Brainery learning, Apprenticeship Program growth, and highlights from the BK Career Fair and team events.
 date: 2022-04-02

--- a/updates/digest/117-pick-up-bao-minh-insurance-card.md
+++ b/updates/digest/117-pick-up-bao-minh-insurance-card.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#117 - Pick up Bao Minh Insurance Card"
 description: Welcome back from vacation with updates on contributor rewards, insurance card pick-up, and new Data and Fullstack Engineers joining the team.
 date: 2022-04-11

--- a/updates/digest/118-apprenticeship-sharing-updates-on-april-brainery-inputs-bao-minh-insurance.md
+++ b/updates/digest/118-apprenticeship-sharing-updates-on-april-brainery-inputs-bao-minh-insurance.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#118 - Apprenticeship Sharing & Updates on April Brainery Inputs & Bao Minh Insurance"
 description: Apply now for Apprenticeship 2022 before the deadline and explore new learning resources, insurance updates, and team news at d.foundation.
 date: 2022-04-18

--- a/updates/digest/119-holiday-announcement.md
+++ b/updates/digest/119-holiday-announcement.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#119 - Holiday announcement"
 description: Visit the Danang office to watch Tom’s vlogs, get flight ticket support, update your ID, check Bao Minh Insurance claims, and note the upcoming holiday schedule.
 date: 2022-04-25

--- a/updates/digest/12-hitting-the-first-milestone-of-tech-radar.md
+++ b/updates/digest/12-hitting-the-first-milestone-of-tech-radar.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#12 - Hitting the first milestone of Tech Radar"
 description: Discover how our team overcame challenges with improved collaboration, automated processes, and upcoming Tech Radar highlights, plus updates on smoother TransferWise payments.
 date: 2020-02-22

--- a/updates/digest/12-summer-moments.md
+++ b/updates/digest/12-summer-moments.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly digest #12: Summer moments - Our team's remote work adventures"
 short_title: "#12 Summer moments"
 description: There’s something special about bringing people together. Even as a remote team, we connect through shared interests and activities. "This summer, Where Are You Working From?" campaign sparked a wave of fun and connection across the team. Come along as we share the stories of our team members.

--- a/updates/digest/120-new-hub-in-dalat-new-teammates-2022-health-checkup.md
+++ b/updates/digest/120-new-hub-in-dalat-new-teammates-2022-health-checkup.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#120 - New Hub in Dalat, New Teammates & 2022 Health Checkup"
 description: Get details on annual health checkups in Saigon, Hanoi, Dalat, and Danang, plus updates on apprenticeships, internships, and the Dalat Hub launch.
 date: 2022-05-09

--- a/updates/digest/121-blood-urine-checkup-for-sg-folks.md
+++ b/updates/digest/121-blood-urine-checkup-for-sg-folks.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#121 - Blood & Urine checkup for SG folks"
 description: Blood and urine tests for SG members are scheduled on May 18, with apprenticeship training starting May 23 and new interns joining the team soon.
 date: 2022-05-17

--- a/updates/digest/122-last-day-of-may.md
+++ b/updates/digest/122-last-day-of-may.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#122 - Last day of May"
 description: "Stay updated on Dwarves' health check-ups, May knowledge contributors, and upcoming all-hands meeting with team events and safety tips in Saigon."
 date: 2022-05-31

--- a/updates/digest/123-memo-featured-radio-talk.md
+++ b/updates/digest/123-memo-featured-radio-talk.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#123 - Memo featured Radio Talk"
 description: Stay updated with upcoming DevOps, blockchain, and software testing workshops, plus weekly tech talks on React 18 and Remix vs Next.js at Dwarves.
 date: 2022-06-06

--- a/updates/digest/124-compliance-training.md
+++ b/updates/digest/124-compliance-training.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#124 - Compliance Training "
 description: Join our Software Modeling training on June 14 to learn from university lecturers and explore blockchain topics like React 18 Useeffect and Solana tokens.
 date: 2022-06-10

--- a/updates/digest/125-in-dwarves-this-week.md
+++ b/updates/digest/125-in-dwarves-this-week.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#125 - In Dwarves this week"
 description: "Join Dwarves' Brainery for up-to-date craft submissions, weekly minigames with prizes, health check updates, and support from our new Ambassadors boosting social media."
 date: 2022-06-17

--- a/updates/digest/126-latest-in-june.md
+++ b/updates/digest/126-latest-in-june.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#126 - Latest in June"
 description: Learn about the upcoming annual performance review process, brain contributor updates, apprenticeship workshops, and the new Engage to Earn bot for team rewards and growth.
 date: 2022-06-24

--- a/updates/digest/127-closing-june.md
+++ b/updates/digest/127-closing-june.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#127 - Closing June"
 description: Join Dwarves Discord to vote on favorite articles for rewards, submit your June self-review, and explore new Brainery topics in blockchain and engineering.
 date: 2022-07-01

--- a/updates/digest/128-kick-off-july.md
+++ b/updates/digest/128-kick-off-july.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#128 - Kick-off July"
 description: Join the Dwarves team exploring ViteJS, Web3, and DeFi, catch Tom’s Google I/O talk on Kubernetes, and learn about performance reviews and referral bonuses.
 date: 2022-07-08

--- a/updates/digest/129-in-dwarves-this-week.md
+++ b/updates/digest/129-in-dwarves-this-week.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#129 - In Dwarves this week "
 description: "Celebrate team milestones, join Dwarves Network's tech event with Google’s Thanh Le, explore July Brainery tech insights, and apply now for frontend, recruiter, and community roles."
 date: 2022-07-14

--- a/updates/digest/13-df-latest-what-are-we-up-to.md
+++ b/updates/digest/13-df-latest-what-are-we-up-to.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#13 - DF Latest: What Are We Up To?"
 description: Discover how Dwarves Foundation boosts product design, engineering craftsmanship, apprenticeship programs, and MacOS utility Blurred to enhance creativity and focus.
 date: 2020-02-29

--- a/updates/digest/13-more-than-lines-of-code.md
+++ b/updates/digest/13-more-than-lines-of-code.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly digest #13: More than lines of code"
 short_title: "#13 More than lines of code"
 description: "Welcome to this week's edition of our roundup, where we highlight the moments that make us more than just lines of code. This week, we're jet-setting around the world with our team's summer adventures, introducing new memo features, cheering for a beloved teammate's new chapter in the US, and celebrating new born. From beachside workspaces to anime figurine collections, we've got it all."

--- a/updates/digest/130-rolled-out-our-first-monthly-tech-event.md
+++ b/updates/digest/130-rolled-out-our-first-monthly-tech-event.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#130 - Rolled out our first monthly Tech Event"
 description: Join our first tech event recap with Google’s @thanhlv, explore new articles on Atomic Design and HDFS, and book your Performance Review slot now.
 date: 2022-07-22

--- a/updates/digest/131-wrapping-up-our-july.md
+++ b/updates/digest/131-wrapping-up-our-july.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#131 - Wrapping up our July"
 description: Join our July All-hands meeting to catch up on performance reviews, Brainery growth, new team members, and share your latest tips and findings.
 date: 2022-07-29

--- a/updates/digest/132-the-first-week-of-august.md
+++ b/updates/digest/132-the-first-week-of-august.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#132 - The first week of August"
 description: "Celebrate new team members, join lively Discord activities, get ready for Mid-Autumn Festival with mooncakes, and contribute to Brainery's first iOS note at Dwarves."
 date: 2022-08-06

--- a/updates/digest/133-halfway-through-august.md
+++ b/updates/digest/133-halfway-through-august.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#133 - Halfway through August"
 description: Discover our new Marketing executive, upcoming T-shirt batch with size chart, and Mid-Autumn Festival mooncake gift delivery updates for seamless shopping and celebration.
 date: 2022-08-14

--- a/updates/digest/134-introduce-the-dwarves-showcase.md
+++ b/updates/digest/134-introduce-the-dwarves-showcase.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#134 - Introduce the Dwarves Showcase"
 description: Discover the latest Dwarves news on new merchandise kits, Friday Showcase demos, and fresh learning topics like Metaverse and Event sourcing to boost your skills.
 date: 2022-08-21

--- a/updates/digest/135-closing-august-with-many-promising-ideas.md
+++ b/updates/digest/135-closing-august-with-many-promising-ideas.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#135 - Closing August with many promising ideas"
 description: Join the August All-hands meeting to hear about team growth, new referral rewards, probation updates, remote offices, and welcome new members before the holiday break.
 date: 2022-08-26

--- a/updates/digest/136-enjoy-the-moonlight-time.md
+++ b/updates/digest/136-enjoy-the-moonlight-time.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#136 - Enjoy the moonlight time"
 description: Celebrate Mid-Autumn Festival with Mooncake gifts, enjoy team updates on performance reviews, new members, and earn $ICY tokens in the Dwarves Network community.
 date: 2022-09-09

--- a/updates/digest/137-this-week-s-highlight.md
+++ b/updates/digest/137-this-week-s-highlight.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#137 - This Week’s Highlight"
 description: Discover how Hidden Bar became a top Mac menu bar app and explore updates from apprentices and contributors growing the Dwarves Brainery community.
 date: 2022-09-15

--- a/updates/digest/138-any-feedback-for-let-s-hear-it.md
+++ b/updates/digest/138-any-feedback-for-let-s-hear-it.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#138 - Any feedback for Let’s Hear IT?"
 description: Stay updated with the Soft Launch Dwarves Podcast on Spotify and Google Podcast, tech event recaps, apprentice stories, and team news including promotions and merchandise deliveries.
 date: 2022-09-22

--- a/updates/digest/139-another-cycle-gone-by.md
+++ b/updates/digest/139-another-cycle-gone-by.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#139 - Another cycle gone by"
 description: Discover how our team boosted September growth by 50%, shared Apprenticeship 2022 insights, and is hiring a digital marketer to expand our audience.
 date: 2022-09-30

--- a/updates/digest/14-back-to-the-office.md
+++ b/updates/digest/14-back-to-the-office.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly digest #14: Embracing hybrid work - the best of both worlds"
 short_title: "#14 Hybrid work harmony"
 description: Discover how Dwarves embraces hybrid working, blending flexibility with in-person connections. Learn how our office space fosters productivity, learning, and real collaboration, even if it’s just for a day or two a week.

--- a/updates/digest/14-this-week-s-highlight-happy-women-s-day.md
+++ b/updates/digest/14-this-week-s-highlight-happy-women-s-day.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#14 - This week's highlight? Happy women's day"
 description: "Celebrate Women's Day and discover Basecamp's new team interactions, Bao Viet insurance updates, and welcome our latest hires boosting quality and frontend engineering."
 date: 2020-03-07

--- a/updates/digest/140-expanding-the-team.md
+++ b/updates/digest/140-expanding-the-team.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#140 - Expanding the team"
 description: Discover highlights from Apprentices Sharing, a successful Open Fabric case study, and current job openings in digital marketing, operations, recruitment, and community roles.
 date: 2022-10-07

--- a/updates/digest/141-all-about-getting-better.md
+++ b/updates/digest/141-all-about-getting-better.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#141 - All about getting better"
 description: Discover how Dwarves improves project delivery with weekly changelogs, celebrates new partnerships and team wins, and seeks React Native developers for contractor roles.
 date: 2022-10-31

--- a/updates/digest/142-the-return-of-tech-radar.md
+++ b/updates/digest/142-the-return-of-tech-radar.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#142 - The return of Tech Radar"
 description: Tech Radar returns with its 4th edition to help Dwarves decide on new technologies, plus updates on Brainery, events, team wins, and upcoming World Cup fun.
 date: 2022-11-21

--- a/updates/digest/143-halfway-through-december.md
+++ b/updates/digest/143-halfway-through-december.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#143 - Halfway Through December"
 description: Join our December updates featuring a company trip, coding security event, $ICY launch, team highlights, and plans for an exciting year-end party.
 date: 2022-12-17

--- a/updates/digest/144-new-year-holiday-community-earn.md
+++ b/updates/digest/144-new-year-holiday-community-earn.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#144 - New Year Holiday, Community Earn"
 description: Celebrate the New Year with community quests to earn ICY, join tech events, and enjoy gatherings at Dwarves’ Dalat Office open year-round.
 date: 2022-12-27

--- a/updates/digest/145-2022-a-year-gone-by.md
+++ b/updates/digest/145-2022-a-year-gone-by.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#145 - 2022, A Year Gone By"
 description: "Reflect on 2022's milestones, team updates, and upcoming events as we celebrate growth, welcome new members, and prepare for the New Year holiday and all-hands meeting."
 date: 2022-12-31

--- a/updates/digest/146-congrats-doty-and-win-of-the-year-2022.md
+++ b/updates/digest/146-congrats-doty-and-win-of-the-year-2022.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#146 - Congrats DOTY and Win of the Year 2022"
 description: Celebrate DOTY and Win of the Year 2022 with highlights from the Dwarves Year End Party, Tet holiday gifts, bonuses, and team updates.
 date: 2023-01-10

--- a/updates/digest/147-happy-t-t-con-m-o.md
+++ b/updates/digest/147-happy-t-t-con-m-o.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#147 - Happy Tết Con Mèo"
 description: Celebrate Tết Con Mèo 2023 with Dwarves Foundation updates on Lunar New Year schedules, team news, new email domains, and job openings in React Native development.
 date: 2023-01-17

--- a/updates/digest/148-kick-off-2023.md
+++ b/updates/digest/148-kick-off-2023.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#148 - Kick-off 2023"
 description: "Kick off 2023 with Dwarves' new Discord role system, $ICY currency, ?help command, performance reviews, and community goals for an engaging year ahead."
 date: 2023-02-04

--- a/updates/digest/149-chatgpt-ogif-new-project-new-teammates.md
+++ b/updates/digest/149-chatgpt-ogif-new-project-new-teammates.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#149 - ChatGPT, OGIF, New Project, New Teammates"
 description: Discover how our team integrates ChatGPT bots in Discord, boosts remote communication, launches OGIF Friday demos, welcomes new members, and plans upcoming profile photoshoots.
 date: 2023-02-13

--- a/updates/digest/15-have-you-heard-of-humans-in-tech.md
+++ b/updates/digest/15-have-you-heard-of-humans-in-tech.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#15 - Have You Heard of Humans in Tech?"
 description: Discover how Humans in Tech connects developers with the latest tech news, community stories, and events to boost your involvement in the tech industry.
 date: 2020-03-14

--- a/updates/digest/15-new-year-gathering.md
+++ b/updates/digest/15-new-year-gathering.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly digest #15: New year gathering: Sharing Tết, starting strong"
 short_title: "#15 New year gathering"
 description: Tết break came to an end, and the Dwarves team reunited to share stories, reconnect, and kick off the Year of the Snake in style. We brought it all back to Discord, along with a little SOL & ICY drop to start the year right.

--- a/updates/digest/150-the-return-of-tech-radar.md
+++ b/updates/digest/150-the-return-of-tech-radar.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#150 - The Return of Tech Radar"
 description: Discover the latest Tech Radar updates on Elixir, AI, testing, and automation shaping Dwarves’ tech stack, plus team news and upcoming meetings.
 date: 2023-02-20

--- a/updates/digest/151-february-s-updates.md
+++ b/updates/digest/151-february-s-updates.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#151 - February’s Updates"
 description: Discover February’s key updates, team achievements, and upcoming community call details to stay informed and motivated for the next project phase.
 date: 2023-02-27

--- a/updates/digest/152-march-s-updates.md
+++ b/updates/digest/152-march-s-updates.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#152 - March’s Updates"
 description: Discover the latest updates on public tech events with industry partners, and free tickets for LightningCon 2023 in Danang.
 date: 2023-03-13

--- a/updates/digest/153-april-s-updates.md
+++ b/updates/digest/153-april-s-updates.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#153 - April’s Updates"
 description: Discover how AI tools and LLMs boost developer productivity with demos, Golang tips, project highlights, and upcoming tech events in this Dwarves community update.
 date: 2023-05-10

--- a/updates/digest/154-may-s-updates.md
+++ b/updates/digest/154-may-s-updates.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#154 - May's Updates"
 description: Web Team relaunch, LLM in Production, Community Bounties, and other company highlights for May 2023.
 date: 2023-06-07

--- a/updates/digest/158 2023-whats-new-october.md
+++ b/updates/digest/158 2023-whats-new-october.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in October 2023"
 description: Each month, we release a recap noting all the significant changes with our company and our team. October is our month for open-source and reflections.
 date: 2023-11-10

--- a/updates/digest/159 2023-whats-new-november.md
+++ b/updates/digest/159 2023-whats-new-november.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in November 2023"
 description: Each month, we release a recap noting all the significant changes in our company and our team. November is our month for meetups and outstanding craftsmanship.
 date: 2023-12-06

--- a/updates/digest/16-the-dwarves-latest-news.md
+++ b/updates/digest/16-the-dwarves-latest-news.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#16 - The dwarves latest news"
 description: "Stay updated on The Dwarves' latest news including remote work, new hires, Canada sales partnerships, SwiftUI webinar, team jacket plans, and culture book insights."
 date: 2020-03-21

--- a/updates/digest/160 2023-whats-new-december.md
+++ b/updates/digest/160 2023-whats-new-december.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in December 2023"
 description: In December, we launched our Consulting Team, released our finding on tech trends, and last but not least, got everyone ready to wrap up 2023.
 date: 2024-01-03

--- a/updates/digest/161 2024-whats-new-january.md
+++ b/updates/digest/161 2024-whats-new-january.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in January 2024"
 description: "In this first month of 2024, we kept tap of what's brewing in the tech market, while reviewing what we went through in 2023."
 date: 2024-02-07

--- a/updates/digest/162 2024-whats-new-february.md
+++ b/updates/digest/162 2024-whats-new-february.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in February 2024"
 description: "In this second month of 2024, we're eyeing on what's brewing in the tech market, what's happening in our community and internally, the newest topics we're looking forward to researching and putting on the field, and expanding our partner network."
 date: 2024-03-08

--- a/updates/digest/163 2024-whats-new-march.md
+++ b/updates/digest/163 2024-whats-new-march.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in March 2024"
 description: "In this March, we're eyeing on what's brewing in the tech market, ICY updates in 2024, the first offline meetup and product demo."
 date: 2024-04-03

--- a/updates/digest/164 2024-whats-new-april.md
+++ b/updates/digest/164 2024-whats-new-april.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in April 2024"
 description: "In this April, we're focused on memo upgrading, reward system, OGIF, internal tooling, community meetup and market report."
 date: 2024-05-23

--- a/updates/digest/165 2024-whats-new-may.md
+++ b/updates/digest/165 2024-whats-new-may.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in May 2024"
 description: May was our month for meetups, upgrading our monthly learning pool, launching NFT roles for our team members, onboarding new collaboration, recapping Echelon X 2024, and hosting an OGIF office hour.
 date: 2024-06-13

--- a/updates/digest/166 2024-whats-new-june.md
+++ b/updates/digest/166 2024-whats-new-june.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in June 2024"
 description: In June, we expanded our knowledge base on software design, LLMs, and blockchain, while actively encouraging knowledge-sharing through increased ICY rewards. Our Vietnam Tech Scene report highlighted key industry players, and weekly OGIF talks fostered discussions on diverse tech topics like design patterns, data modalities, and blockchain architecture
 date: 2024-07-04

--- a/updates/digest/167 2024-whats-new-july.md
+++ b/updates/digest/167 2024-whats-new-july.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in July 2024"
 description: "Each month, we release a recap highlighting key updates and progress within our team and community. July covers AI advancements, community contributions, insights from Vietnam's tech scene, new memo commands, OGIF automation, and the introduction of our hourly billing model"
 date: 2024-08-09

--- a/updates/digest/168 2024-whats-new-august.md
+++ b/updates/digest/168 2024-whats-new-august.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in August 2024"
 description: Each month, we release a recap highlighting key updates and progress within our team and community. August updates highlight AI tools, enhanced community discussions, the sum command upgrade, Go enterprise MOC insights, and earning dfg tokens through contributions.
 date: 2024-09-06

--- a/updates/digest/169 2024-whats-new-september.md
+++ b/updates/digest/169 2024-whats-new-september.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in September 2024"
 description: "Each month, we roll out a recap of our team and community's strides forward. September's updates spotlight the AI Club launch, rewards for our sharing culture, hybrid work check-ins, reporting tech trends in forward engineering, and our Mid-Autumn celebration."
 date: 2024-10-01

--- a/updates/digest/17-why-people-so-gi-u-lately.md
+++ b/updates/digest/17-why-people-so-gi-u-lately.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#17 - Why People so Giàu lately?"
 description: "Discover how our design team improved fintech apps, shared home desk snapshots, hosted an ADR webinar, and published SwiftUI tutorials in this week's tech update."
 date: 2020-03-28

--- a/updates/digest/170 2024-whats-new-oct.md
+++ b/updates/digest/170 2024-whats-new-oct.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in October 2024"
 description: "Each month, we roll out a recap of our team and community's progress. October's updates spotlight our open source initiative, boosted rewards for sharing knowledge, navigating market shifts, weekly tech insights, and a warm celebration of Vietnamese Women's Day."
 date: 2024-11-15

--- a/updates/digest/171 2024-whats-new-november.md
+++ b/updates/digest/171 2024-whats-new-november.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in November 2024"
 description: In November, we sharpened our focus with advancements in platform engineering, introduced streamlined service packages, elevated ICY rewards for impactful contributions, and embraced key insights from market shifts, all building momentum as we gear up for our Penang retreat.
 date: 2024-12-04

--- a/updates/digest/172 2024-whats-new-december.md
+++ b/updates/digest/172 2024-whats-new-december.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in December 2024"
 description: "December blended Penang team moments with steady progress, closing 2024 with energy and ready for what's next."
 date: 2025-01-03

--- a/updates/digest/173 2025-whats-new-february.md
+++ b/updates/digest/173 2025-whats-new-february.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in February 2025"
 description: "Each month, we roll out a recap of our team and community's strides forward. February's recap covers the hybrid mode shift, ICY-to-BTC swap testing, updated use cases with AI and trading solutions, skip-level meetings, and the New Year gathering kickoff."
 date: 2025-03-04

--- a/updates/digest/174 2025-whats-new-march.md
+++ b/updates/digest/174 2025-whats-new-march.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in March 2025"
 description: "Last month, the team kicked off structured OGIF demos, launched GitHub Agent and MCP DB to support internal automation, finalized the ICY-BTC swap, and rolled out UI and handbook updates on memo.d.foundation. We also set a more consistent office rhythm with meme culture picking up, while the BD team tuned into regional AI and Web3 events to stay close to what's happening next."
 date: 2025-04-02

--- a/updates/digest/175 2025-whats-new-april.md
+++ b/updates/digest/175 2025-whats-new-april.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in April 2025"
 description: "In April, we reorganized Memo into a clearer knowledge hub, made internal tools easier to adopt with MCP documentation, and aligned consulting delivery with hiring signals. Our shift to Vietnamese content on social media sparked strong engagement, while weekly team efforts continued to surface insights through build logs and learning highlights."
 date: 2025-05-12

--- a/updates/digest/176 2025-whats-new-may.md
+++ b/updates/digest/176 2025-whats-new-may.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in May 2025"
 description: "In May, we rolled out Memo’s on-chain publishing with optional NFT minting, tested internal tooling like MCP Playbook in real usage, and turned consulting projects into spaces to refine our workflow. Prompt DB and Observer Log matured into working systems, while Forward Engineering documented hands-on experiments across the team."
 date: 2025-06-04

--- a/updates/digest/18-releases-of-the-week.md
+++ b/updates/digest/18-releases-of-the-week.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#18 - Releases of the Week"
 description: Discover the latest updates from Dwarves including new features, team updates, and a new site for coding vibes.
 date: 2020-04-04

--- a/updates/digest/19-your-team-jacket-is-ready-to-pick.md
+++ b/updates/digest/19-your-team-jacket-is-ready-to-pick.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#19 - Your team jacket is ready to pick"
 description: Get the latest updates on your team jacket pickup, newbie orientation slides, chill music playlists, and an insightful interview with Backend Engineer Huy N. at Dwarves Foundation.
 date: 2020-04-11

--- a/updates/digest/2-walk-around-learn-around.md
+++ b/updates/digest/2-walk-around-learn-around.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly digest #2: Walk around learn around"
 short_title: "#2 Walk around learn around"
 description: There are so many amazingly fun and wonderfully weird things happening on Discord, both last week and of course, today. So let’s dive in with a freshly-brewed “cà phê sữa,” of course.

--- a/updates/digest/20-this-is-mail-subject.md
+++ b/updates/digest/20-this-is-mail-subject.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#20 - This is mail subject"
 description: "Discover the latest sudo.fm updates, team learning accounts, a fun dog photo site, jacket pickups, and a growing team library in this week's quarantine roundup."
 date: 2020-04-18

--- a/updates/digest/2018-in-review.md
+++ b/updates/digest/2018-in-review.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: 2018 in review
 description: 2018 notable hightlights and achievements
 date: 2018-12-31

--- a/updates/digest/2019-in-review.md
+++ b/updates/digest/2019-in-review.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: 2019 in review
 description: 2019 notable highlights and achievements
 date: 2020-01-25

--- a/updates/digest/2020-in-review.md
+++ b/updates/digest/2020-in-review.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: 2020 in review
 description: 2020 notable highlights and achievements
 date: 2021-02-05

--- a/updates/digest/2021-dwarves-of-the-year.md
+++ b/updates/digest/2021-dwarves-of-the-year.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Dwarves of the year 2021
 description: "A big congratulations to our Dwarves of 2021. Apart from the team's voting result for each title, the team leads also selected the Honorable Mention and Client Endorsed, as we want to honor all of the hard work."
 date: 2022-01-05

--- a/updates/digest/2021-in-review.md
+++ b/updates/digest/2021-in-review.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: 2021 in review
 description: 2021 notable highlights and achievements
 date: 2021-02-05

--- a/updates/digest/2021-whats-new-december.md
+++ b/updates/digest/2021-whats-new-december.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in December 2021"
 description: Each month, we release a recap noting all the significant changes with our company and our team. December 2022 will go over our growth in blockchain, team members, upgrade on the benefits packages.
 date: 2022-01-06

--- a/updates/digest/2021-whats-new-july.md
+++ b/updates/digest/2021-whats-new-july.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in July 2021"
 description: Each month, we release a recap noting all the significant changes with our company and our team. July 2021 we will move toward blockchain industry and prepare for performance review in August.
 date: 2021-07-31

--- a/updates/digest/2022-dwarves-of-the-year.md
+++ b/updates/digest/2022-dwarves-of-the-year.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Dwarves of the year 2022
 description: "It's been a long journey, but we've finally made it to 2022 and what a year it's been for our team of Dwarves. Countless hours of hard work and it's all paid off with our big wins of the year. Honored for all and huge congratulations for our Dwarves of 2022."
 date: 2023-01-19

--- a/updates/digest/2022-in-review.md
+++ b/updates/digest/2022-in-review.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: 2022 in review
 description: Successfully went through 2022, a year that we might say -  a new record team reached highest growth record, kickstarted community engagement, home, compliance training & individual development are speeding up, and a whole new place to call Dwarves.
 date: 2023-01-19

--- a/updates/digest/2022-summit-engineering-a-good-time.md
+++ b/updates/digest/2022-summit-engineering-a-good-time.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Summit 2022: Engineering a good time"
 description: Having a blast company trip after 2 years of COVID, it didn’t happen in a common way. We planned our trip differently than others and designed apps for everyone to play as a way to bond as company outside physical activities.
 date: 2023-01-09

--- a/updates/digest/2022-whats-new-january.md
+++ b/updates/digest/2022-whats-new-january.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in January 2022"
 description: Each month, we release a recap noting all the significant changes with our company and our team. January 2022 will go over performance review and our growth on projects, new year highlights.
 date: 2022-01-28

--- a/updates/digest/2022-whats-new-may.md
+++ b/updates/digest/2022-whats-new-may.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "What's new in May 2022"
 description: Each month, we release a recap noting all the significant changes with our company and our team. In May, we kicked off Apprenticeship training, and our new chalet is ready for community to visit.
 date: 2022-05-31

--- a/updates/digest/2023-happy.md
+++ b/updates/digest/2023-happy.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Happy 2023
 description: As we enter a new year, I want to reflect on the role that software has played in my life. For Dwarves 2.x, our goal has always been to be a borderless software firm. As we move into 2022, we are one step closer to achieving this goal. We strive to operate in new and efficient ways, different from the rest. Some of us are working with our peers to help ship their software, while others are building their own projects and striving for excellence. We are all making our way towards achieving excellence in our field.
 date: 2023-01-22

--- a/updates/digest/2024-community-meet-up.md
+++ b/updates/digest/2024-community-meet-up.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Dwarves' 2nd community offline meet-up"
 description: At the end of May, we had the pleasure of hosting our second community meet-up. Over 50 folks, including notable community members, joined us.
 date: 2024-06-11

--- a/updates/digest/2024-in-review.md
+++ b/updates/digest/2024-in-review.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: 2024 in review
 description: "Closing another milestone with 2024, it has been a year of building and rebuilding ,  strengthening what works, fixing what doesn't, and uncovering new paths along the way. Every milestone reached this year carries the marks of teamwork and persistence."
 date: 2025-01-16

--- a/updates/digest/2024-navigating-changes.md
+++ b/updates/digest/2024-navigating-changes.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Navigating changes
 description: "The last tech cycle is ending, and we're already in the new normal. We are not in the best shape to compete with certain competitors, especially with a new market meta emerging. We are now in a future of new automation paradigms via AI and assets are moving on-chain."
 date: 2024-09-30

--- a/updates/digest/2024-semi-annual-review.md
+++ b/updates/digest/2024-semi-annual-review.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "State of dwarves: 2024 semi-annual review"
 description: "The past six months have been packed with many improvements to our Discord server from new standards and automation to engaging activities and rewards. Take a moment to reflect on our journey so far, and let's get excited about what we'll accomplish together before the year ends."
 date: 2024-07-04

--- a/updates/digest/2024-summit-building-bonds-our-way.md
+++ b/updates/digest/2024-summit-building-bonds-our-way.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Summit 2024: Building bonds our way"
 description: Our first international summit took us to Penang, where remote connections turned into real-world chemistry. No rigid schedules or forced activities - just authentic moments of teams choosing their own adventures, from heritage streets to beach sunsets. See how giving people space to connect creates something truly special.
 date: 2024-12-24

--- a/updates/digest/2025-days-in-danang.md
+++ b/updates/digest/2025-days-in-danang.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Summit 2025: Days in Danang"
 description: "We organized a few offline days  in Danang: a climb to a lookout, quiet courtyards, a walk by the water, and an evening in the old streets. The time together gave us better context across squads and made day-to-day coordination easier."
 date: 2025-10-22

--- a/updates/digest/21-software-craftsmanship-at-dwarves.md
+++ b/updates/digest/21-software-craftsmanship-at-dwarves.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#21 - Software Craftsmanship at Dwarves"
 description: Discover how Software Craftsmanship at DF blends skill, mindset, and Agile practices to create well-crafted software and boost team knowledge sharing.
 date: 2020-04-25

--- a/updates/digest/22-we-created-some-cool-stuffs.md
+++ b/updates/digest/22-we-created-some-cool-stuffs.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#22 - We created some cool stuffs"
 description: Discover new remote work tips, daily English learning, unique team traditions, and monthly movie picks in our latest update for a fun and productive holiday season.
 date: 2020-05-02

--- a/updates/digest/23-cycle-updates-transcripts-project-highlight-what-a-week.md
+++ b/updates/digest/23-cycle-updates-transcripts-project-highlight-what-a-week.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#23 - Cycle Updates, Transcripts & Project Highlight, what a week!"
 description: Discover how Software Craftsmanship at DF enhances engineering skills, promotes well-crafted software, and improves mobile app design for better user experience.
 date: 2020-05-09

--- a/updates/digest/24-memo-is-getting-piled-up.md
+++ b/updates/digest/24-memo-is-getting-piled-up.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#24 - Memo is getting piled up"
 description: Learn how Software Modeling improves maintainability and scalability, and explore practical design system tips including naming conventions and auto layout in Figma.
 date: 2020-05-16

--- a/updates/digest/25-readify-has-been-on-appstore.md
+++ b/updates/digest/25-readify-has-been-on-appstore.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#25 - Readify has been on AppStore"
 description: "Explore Dwarves Foundation's 5-year journey, software development basics, remote work tips with Basecamp, and Readify's new App Store bookmark features."
 date: 2020-05-23

--- a/updates/digest/26-are-you-a-mouse-less-user.md
+++ b/updates/digest/26-are-you-a-mouse-less-user.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#26 - Are you a Mouse-less User ?"
 description: Discover Vim Motion, an app inspired by vim-easymotion that simplifies keyboard navigation for faster, mouse-free control of UI elements.
 date: 2020-05-30

--- a/updates/digest/27-week-in-review.md
+++ b/updates/digest/27-week-in-review.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#27 - Week in Review"
 description: Discover how Dwarves team expands with new QA and Design members, embraces transparency and feedback culture, and shares tech stories while advancing projects like sudo.fm.
 date: 2020-06-06

--- a/updates/digest/28-quite-late-but-here-s-what-happened-this-week.md
+++ b/updates/digest/28-quite-late-but-here-s-what-happened-this-week.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#28 - Quite late, but here’s what happened this week"
 description: Join Memo’s writing team to share your voice, learn about our new US healthcare project, and meet five new interns joining us this July.
 date: 2020-06-13

--- a/updates/digest/29-had-enough-of-things-tired-of-people-fed-up-from-work.md
+++ b/updates/digest/29-had-enough-of-things-tired-of-people-fed-up-from-work.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#29 - Had Enough of Things? Tired of People? Fed up from Work?"
 description: Join our anonymous feedback form, RSVP for the July 3rd End of Cycle Dinner, and explore the updated Dwarves Playbook for software development insights.
 date: 2020-06-20

--- a/updates/digest/3-we-all-start-somewhere.md
+++ b/updates/digest/3-we-all-start-somewhere.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly digest #3: We all start somewhere"
 short_title: "#3 We all start somewhere"
 description: "Huge news is on the horizon. You absolutely will not guess what we’re about to share. Excitement building, we remember last week like it was yesterday, but what truly counts is that you're here with us."

--- a/updates/digest/30-the-last-few-days-for-end-of-cycle-dinner-rsvp.md
+++ b/updates/digest/30-the-last-few-days-for-end-of-cycle-dinner-rsvp.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#30 - The Last Few Days for End of Cycle Dinner RSVP"
 description: "Discover the redesigned Dwarves website Work section, insights on company culture with 'People Matter,' and RSVP details for the upcoming End of Cycle Dinner."
 date: 2020-06-27

--- a/updates/digest/31-the-3rd-cycle-review.md
+++ b/updates/digest/31-the-3rd-cycle-review.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#31 - The 3rd Cycle Review 📍"
 description: Celebrate the end of the 3rd cycle with highlights on the Cryptosy app update, team achievements, and a fun dinner gathering with food and drinks.
 date: 2020-07-04

--- a/updates/digest/32-drop-your-next-goal-in-cycle-planning.md
+++ b/updates/digest/32-drop-your-next-goal-in-cycle-planning.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#32 - Drop your next goal in Cycle Planning"
 description: Discover the July-August 2020 cycle plan focusing on partnership expansion, tech upgrades, upcoming performance reviews, and highlights from Golang Meetup
 date: 2020-07-11

--- a/updates/digest/33-csr-program-solve-social-causes-using-technology-products.md
+++ b/updates/digest/33-csr-program-solve-social-causes-using-technology-products.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#33 - CSR Program: Solve Social Causes using Technology Products"
 description: Discover how our CSR program supports social causes by offering free website development, including a new app connecting cancer patients with helpful events.
 date: 2020-07-18

--- a/updates/digest/34-dwarves-updates.md
+++ b/updates/digest/34-dwarves-updates.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#34 - Dwarves Updates"
 description: Discover our company culture code, Canada internship updates, and insights on startups hiring junior designers from a design lead’s perspective in this concise blog post.
 date: 2020-07-25

--- a/updates/digest/35-just-can-t-believe-it-s-been-august-already.md
+++ b/updates/digest/35-just-can-t-believe-it-s-been-august-already.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#35 - Just can’t believe it’s been August already"
 description: Stay updated on Covid impacts, company innovation, new tech topics like SwiftUI and security, Readify app progress, and welcome our first Canada internship batch.
 date: 2020-08-01

--- a/updates/digest/36-find-your-topic-on-memo.md
+++ b/updates/digest/36-find-your-topic-on-memo.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#36 - Find Your Topic on Memo"
 description: Discover how TechRadar research is published on Dwarves Memo, get updates on the Dwarves team week overview, and learn Deckset slide guidelines with VSCode.
 date: 2020-08-08

--- a/updates/digest/37-handbook-update-routine-a-typical-week-with-us.md
+++ b/updates/digest/37-handbook-update-routine-a-typical-week-with-us.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#37 - Handbook update: Routine/ A typical week with us"
 description: Learn about our team’s typical weekly routine and explore our Covid Support program offering affordable tech services to help SMEs and startups thrive remotely.
 date: 2020-08-15

--- a/updates/digest/38-what-s-left-to-clean-up.md
+++ b/updates/digest/38-what-s-left-to-clean-up.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#38 - What’s left to clean up"
 description: Prepare for the upcoming cycle review by wrapping up your work and submit your Mid-Autumn Festival gift delivery address by August 31 for doorstep delivery.
 date: 2020-08-22

--- a/updates/digest/39-july-august-cycle-review.md
+++ b/updates/digest/39-july-august-cycle-review.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#39 - July/August Cycle review"
 description: Discover the latest July-August tech insights from Dwarves, covering WebAssembly, Progressive Web Apps, SwiftUI, UX testing, Blockchain design, and more innovations.
 date: 2020-08-29

--- a/updates/digest/4-finding-your-authentic-tribe.md
+++ b/updates/digest/4-finding-your-authentic-tribe.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly digest #4: Finding your authentic tribe"
 short_title: "#4 Finding your authentic tribe"
 description: "Welcome back to the #4 weekly digest after a long holiday. Those Discord channels are still buzzing with active messages. Without further ado, let’s see what I’ve got to share."

--- a/updates/digest/40-collect-your-totem.md
+++ b/updates/digest/40-collect-your-totem.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#40 - Collect your totem 🛠"
 description: Discover the latest updates from Dwarves including totem giveaways, TechRadar achievements, new project tracking with Hill charts, and welcoming frontend engineer Hieu Ngo.
 date: 2020-09-05

--- a/updates/digest/41-dwarves-updates-weup-nyp.md
+++ b/updates/digest/41-dwarves-updates-weup-nyp.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#41 - Dwarves Updates: WeUp & NYP"
 description: Discover how Dwarves Foundation enhances internships, partnership opportunities, project management, and workflow optimization to deliver outstanding client and team experiences.
 date: 2020-09-12

--- a/updates/digest/42-update-on-cea-and-conference-allowance.md
+++ b/updates/digest/42-update-on-cea-and-conference-allowance.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#42 - Update on CEA and Conference Allowance"
 description: Learn about updated conference and education allowances, Lap’s infinite image gallery with ThreeJS, and the new standard Restful API design for consistent development.
 date: 2020-09-26

--- a/updates/digest/43-standardize-diagram.md
+++ b/updates/digest/43-standardize-diagram.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#43 - Standardize tech progress: Diagram"
 description: Learn how to standardize tech progress with Mermaid diagrams, RESTful API design, and stay updated on logging, monitoring, and new Biz Dev team additions at Dwarves.
 date: 2020-10-03

--- a/updates/digest/44-latest-adoption-api-new-practice-hubspot.md
+++ b/updates/digest/44-latest-adoption-api-new-practice-hubspot.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#44 - Latest Adoption: API New Practice & Hubspot"
 description: Learn how our new API naming convention improves project management and how centralizing data on Hubspot enhances team access and customer experience.
 date: 2020-10-10

--- a/updates/digest/45-sentry-adoption-website-upgrade-projects-output.md
+++ b/updates/digest/45-sentry-adoption-website-upgrade-projects-output.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#45 - Sentry Adoption, Website upgrade & Projects Output"
 description: Learn how our team adopted a new monitoring stack using Grafana, Loki, and Sentry to improve application status tracking and updated websites with Tailwind CSS.
 date: 2020-10-17

--- a/updates/digest/46-how-we-level-up-project-status-tracking.md
+++ b/updates/digest/46-how-we-level-up-project-status-tracking.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#46 - How we level up project status tracking"
 description: Discover how our bi-weekly progress summaries, monthly client newsletters, and improved onboarding process enhance communication, client experience, and team integration effectively.
 date: 2020-10-24

--- a/updates/digest/48-sep-oct-cycle-updates.md
+++ b/updates/digest/48-sep-oct-cycle-updates.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#48 - Sep-Oct cycle updates"
 description: Discover the latest Sep-Oct 2020 updates on community work, product completion, tech practice, and upcoming training courses from our team retreat at Bia Craft.
 date: 2020-10-31

--- a/updates/digest/49-information-workflow-gathering-output-for-project-report.md
+++ b/updates/digest/49-information-workflow-gathering-output-for-project-report.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#49 - Information workflow - Gathering output for project report"
 description: Learn how to streamline release workflows by converting development updates into clear sprint-based reports for internal teams and external clients.
 date: 2020-11-07

--- a/updates/digest/5-delay-the-gratification.md
+++ b/updates/digest/5-delay-the-gratification.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly digest #5: endure the hardship, delay the gratification"
 short_title: "#5 Endure the hardship, delay the gratification"
 description: Happy Monday, I’m here again, bringing you a lot of updates. There are big and small things brewing at Dwarves network. As we keep on crafting a better community day by day with you.

--- a/updates/digest/50-too-many-news-i-find-it-hard-to-choose-a-subject.md
+++ b/updates/digest/50-too-many-news-i-find-it-hard-to-choose-a-subject.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#50 - Too many news I find it hard to choose a subject"
 description: Discover how Ventures upgraded their website perks, automated project backups, and prepared Readify MVP with data integration, plus community events and the latest Apple M1 news.
 date: 2020-11-14

--- a/updates/digest/51-any-feedback-for-readify.md
+++ b/updates/digest/51-any-feedback-for-readify.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#51 - Any feedback for Readify?"
 description: Readify updates, Mermaid diagram redesign, YearEnd party plans, GitHub restoring youtube-dl, Apple lowering App Store fees, and TailwindCSS v2.0 release highlights.
 date: 2020-11-21

--- a/updates/digest/52-we-sent-out-the-first-monthly-project-report.md
+++ b/updates/digest/52-we-sent-out-the-first-monthly-project-report.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#52 - We sent out the first Monthly Project Report"
 description: Stay updated on our smooth project progress, new memo rules, upcoming WeBuild day event, year-end party plans, and the latest PHP v8 release news.
 date: 2020-11-28

--- a/updates/digest/53-dwarves-latest-in-dec-webuild-day-website-update-english-class.md
+++ b/updates/digest/53-dwarves-latest-in-dec-webuild-day-website-update-english-class.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#53 - Dwarves Latest in Dec: WeBuild day, Website update & English class"
 description: Get the latest updates on Covid-19, Artzy.vn improvements, WeBuild day, The Library Project partnership, Salesforce-Slack deal, and new English classes for our community.
 date: 2020-12-05

--- a/updates/digest/54-webuild-day-block71-saigon.md
+++ b/updates/digest/54-webuild-day-block71-saigon.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#54 - Webuild day @ Block71 Saigon"
 description: Discover the latest updates on Puffer’s development, tech stack integration on d.foundation, Webuild day highlights, and key tech industry news including Samsung and Airbnb insights.
 date: 2020-12-12

--- a/updates/digest/55-sent-out-our-first-weekly-project-changelog.md
+++ b/updates/digest/55-sent-out-our-first-weekly-project-changelog.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#55 - Sent out our first weekly Project Changelog"
 description: Stay updated with our weekly project changelog featuring new developments on Quod.ai, WeUp, WeGo, team updates, and insights on the Facebook vs Apple privacy debate.
 date: 2020-12-19

--- a/updates/digest/56-happy-belated-christmas.md
+++ b/updates/digest/56-happy-belated-christmas.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#56 - Happy belated Christmas ❄️"
 description: "Discover highlights from our Noel gift exchange, the launch of our team website, and Zoom's plan to shift toward an enterprise app suite with email and calendar features."
 date: 2020-12-26

--- a/updates/digest/57-and-it-s-a-wrap.md
+++ b/updates/digest/57-and-it-s-a-wrap.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#57 - And it’s a Wrap"
 description: Reflect on 2020’s challenges, celebrate the Dwarves’ 6th birthday, join new consultant training, and learn about Microsoft’s SolarWinds source code breach news.
 date: 2021-01-01

--- a/updates/digest/58-we-re-moving.md
+++ b/updates/digest/58-we-re-moving.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#58 - We’re Moving"
 description: Discover updates on the new office migration, team retreat, and Apple’s innovative wireless charger patents for MacBook in this week’s news roundup.
 date: 2021-01-09

--- a/updates/digest/59-the-dwarves-turns-6.md
+++ b/updates/digest/59-the-dwarves-turns-6.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#59 - The Dwarves turns 6"
 description: "Celebrate the Dwarves' 6th anniversary, explore new open-source contributions, tech research updates, upcoming performance reviews, and the latest WhatsApp privacy controversy."
 date: 2021-01-16

--- a/updates/digest/6-stay-for-the-culture.md
+++ b/updates/digest/6-stay-for-the-culture.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly digest #6: Come for the conversation, stay for the culture"
 short_title: "#6 Come for the conversation, stay for the culture"
 description: "Hi, it’s @innno again. Summer is almost here. But don't worry, this update is all about making your day more comfortable. Now, onto this week’s updates."

--- a/updates/digest/60-got-any-topic-to-ask-pitch-it.md
+++ b/updates/digest/60-got-any-topic-to-ask-pitch-it.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#60 - Got any topic to ask? Pitch it"
 description: Get the latest updates on startup talks, tech tools like Volta and Earthly, office moves, healthcare plans, and Apple’s new MacBook Pro design.
 date: 2021-01-23

--- a/updates/digest/61-lunar-new-year-gift.md
+++ b/updates/digest/61-lunar-new-year-gift.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#61 - Lunar new year gift"
 description: Get ready for Lunar New Year gifts, visit the new HaDo office, say farewell to Nghia Pham, and follow the Facebook vs Apple legal battle over data privacy.
 date: 2021-01-30

--- a/updates/digest/62-2020-wrapping-up.md
+++ b/updates/digest/62-2020-wrapping-up.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#62 - 2020 Wrapping Up"
 description: Review 2020 highlights, Lunar New Year gifts, an AMA with Duc Nghiem, WeUp product demo, and Jeff Bezos stepping down as Amazon CEO.
 date: 2021-02-06

--- a/updates/digest/63-buckle-up-for-2021.md
+++ b/updates/digest/63-buckle-up-for-2021.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#63 - Buckle up for 2021"
 description: Stay healthy with our March healthcare checkup dates, discover the new Etam coffee maker at HaDo office, and explore 2021 tech trends and interview insights.
 date: 2021-02-20

--- a/updates/digest/64-finished-the-first-cycle-of-2021.md
+++ b/updates/digest/64-finished-the-first-cycle-of-2021.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#64 - Finished the first Cycle of 2021"
 description: Discover key updates from the Jan/Feb changelog, including Discord’s switch from Go to Rust for better performance and new tools for personal branding.
 date: 2021-02-27

--- a/updates/digest/65-it-s-getting-real-in-tech-adoption.md
+++ b/updates/digest/65-it-s-getting-real-in-tech-adoption.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#65 - It’s getting real in Tech “Adoption”"
 description: Discover how Webflow and Bubble.io boost real estate and US projects, explore startup stages, and check the latest tech news on Flutter 2.0 and Brave’s private search engine.
 date: 2021-03-06

--- a/updates/digest/66-apprenticeship-preparation.md
+++ b/updates/digest/66-apprenticeship-preparation.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#66 - Apprenticeship Preparation"
 description: Discover our apprenticeship program for engineers, health check reminders, insights on software engineering, Discord updates, GitHub CLI tips, and simple writing advice in this weekly update.
 date: 2021-03-13

--- a/updates/digest/67-official-launch-of-apprenticeship.md
+++ b/updates/digest/67-official-launch-of-apprenticeship.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#67 - Official Launch of Apprenticeship"
 description: "Discover the latest updates on Dwarves' apprenticeship launch, venture funds, healthcare checkups, project delivery improvements, and key tech news on Rust, Go, Docker, and Tinder background checks."
 date: 2021-03-20

--- a/updates/digest/68-moving-from-gbp-to-usd.md
+++ b/updates/digest/68-moving-from-gbp-to-usd.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#68 - Moving from GBP to USD"
 description: Discover how The Dwarves boost Malaysia’s fuel e-payment app with tech upgrades, apprenticeship growth, no-code projects, and client-focused quality improvements.
 date: 2021-03-27

--- a/updates/digest/69-closing-march.md
+++ b/updates/digest/69-closing-march.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#69 - Closing March"
 description: Discover how our growing BE team, quality improvements, new newsletters, and community efforts are driving better service, marketing, and tech insights at Dwarves.
 date: 2021-04-03

--- a/updates/digest/7-a-journey-through-time.md
+++ b/updates/digest/7-a-journey-through-time.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly digest #7: A journey through time"
 short_title: "#7 A journey through time"
 description: "The sun peeks over the horizon, Saturday vibes and good news – the perfect combo. We're about to spice up your weekend with a recap of all the awesome things we whipped up this week."

--- a/updates/digest/70-new-workflow-update-changelog-compliance.md
+++ b/updates/digest/70-new-workflow-update-changelog-compliance.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#70 - New workflow update : Changelog & Compliance"
 description: Learn about our new apprenticeship program, project workflow improvements, quality control updates, and the latest tech news including Kotlin Multiplatform and data breach insights.
 date: 2021-04-10

--- a/updates/digest/71-holiday-day-off-and-the-rollout-of-obvs.md
+++ b/updates/digest/71-holiday-day-off-and-the-rollout-of-obvs.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#71 - Holiday Day-off and the rollout of Obvs"
 description: Stay updated with team progress, apprenticeship growth, Testlink QC tools, upcoming holidays, the new Obvs newsletter, Microsoft-Nuance AI healthcare acquisition, and GitHub Actions benefits.
 date: 2021-04-17

--- a/updates/digest/72-apprenticeship-wrapping-up.md
+++ b/updates/digest/72-apprenticeship-wrapping-up.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#72 - Apprenticeship wrapping up"
 description: "Discover the latest team updates, project progress, Apple Spring Event highlights, and a comparison of GCP with AWS and Azure in this week's tech roundup."
 date: 2021-04-24

--- a/updates/digest/73-changelog-for-march-and-april.md
+++ b/updates/digest/73-changelog-for-march-and-april.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#73 - Changelog for March and April"
 description: Discover the latest team updates, CSS tips, and insights on combining Golang and Elixir for better web development in our Mar/Apr changelog.
 date: 2021-05-01

--- a/updates/digest/74-project-wrap-up-and-workload-distribution.md
+++ b/updates/digest/74-project-wrap-up-and-workload-distribution.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#74 - Project Wrap up and Workload Distribution"
 description: "Discover why Rust is emerging as the top modern programming language, with growing adoption by major companies like Google and Discord challenging Go's dominance."
 date: 2021-05-08

--- a/updates/digest/75-project-updates.md
+++ b/updates/digest/75-project-updates.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#75 - Project Updates"
 description: Stay updated on community projects, Covid work-from-home tips, VssID social insurance app, Google Docs canvas rendering, and Notion’s new public API rollout.
 date: 2021-05-15

--- a/updates/digest/76-resource-allocation-and-monthly-all-hands-meeting.md
+++ b/updates/digest/76-resource-allocation-and-monthly-all-hands-meeting.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#76 - Resource Allocation, and monthly all-hands meeting"
 description: Discover the latest updates on apprenticeship DevOps training, monthly all-hands meetings, programming fundamentals insights, and the new Sublime Text 4 release for developers.
 date: 2021-05-22

--- a/updates/digest/77-may-all-hands-meeting.md
+++ b/updates/digest/77-may-all-hands-meeting.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#77 - May all-hands meeting"
 description: Discover key insights from our May All-hands meeting, on-leave scheduling tips, UIView design principles, and API improvement strategies for better software performance.
 date: 2021-05-29

--- a/updates/digest/78-apprenticeship-shifting-training-layout.md
+++ b/updates/digest/78-apprenticeship-shifting-training-layout.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#78 - Apprenticeship: shifting training layout"
 description: Discover our updated apprenticeship training on soft skills and team communication, new English name conventions for Basecamp, Firefox’s redesigned browser, and StackOverflow’s $1.8B acquisition.
 date: 2021-06-05

--- a/updates/digest/79-dwarvesf-brain-repo-sync-up-product-wishlist.md
+++ b/updates/digest/79-dwarvesf-brain-repo-sync-up-product-wishlist.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#79 - Dwarvesf/brain repo sync up & product wishlist"
 description: Discover how dwarvesf/brain enhances team knowledge sharing with Zettelkasten notes, communication training, Apple WWDC updates, Elixir tips, and Discord Nitro offers.
 date: 2021-06-12

--- a/updates/digest/8-then-came-the-last-days-of-may.md
+++ b/updates/digest/8-then-came-the-last-days-of-may.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly digest #8: Then came the last days of May"
 short_title: "#8 Then came the last days of May"
 description: "Here's to hoping for a brighter and better month on this last day of May. We’re in the heat of a community offline meet-up today, gathering to discuss the month’s progress. Everyone's a bit busy arranging their travel to Saigon, a wild place we all call home. So, let’s dive into what we’ve been up to."

--- a/updates/digest/80-in-the-remote-movement.md
+++ b/updates/digest/80-in-the-remote-movement.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#80 - In the remote movement"
 description: Discover how our team uses metrics dashboards, automation testing, and remote tools like Gather Town to boost productivity while exploring the latest Windows 11 rumors and Apple M1 insights.
 date: 2021-06-19

--- a/updates/digest/81-jun-update-cleaning-up-the-roadmap.md
+++ b/updates/digest/81-jun-update-cleaning-up-the-roadmap.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#81 - Jun Update: Cleaning up the Roadmap"
 description: "Stay updated on team roadmap changes, Covid impacts in Saigon, Notion adoption for projects, Brave search beta features, and GitHub's new collaboration tools."
 date: 2021-06-26

--- a/updates/digest/82-enjoy-the-upgrade.md
+++ b/updates/digest/82-enjoy-the-upgrade.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#82 - Enjoy the upgrade"
 description: Stay updated with our July-August goals, new SQL and application design lessons, Micro Frontend research, and office item shipments in our latest team update.
 date: 2021-07-10

--- a/updates/digest/83-new-work-with-notion-reward-on-brain-repo.md
+++ b/updates/digest/83-new-work-with-notion-reward-on-brain-repo.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#83 - New work with Notion & Reward on Brain repo"
 description: Discover Dwarves Updates, new startup directories, team rewards, and insights on remote work and decision-making in our latest monthly newsletter and blog posts.
 date: 2021-07-17

--- a/updates/digest/84-what-s-your-mbti.md
+++ b/updates/digest/84-what-s-your-mbti.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#84 - What's your MBTI?"
 description: "Discover your team's MBTI results, explore the new Notion migration for memos and project updates, and join AMA office hours for all your product questions."
 date: 2021-07-24

--- a/updates/digest/85-july-s-updates.md
+++ b/updates/digest/85-july-s-updates.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#85 - July's updates"
 description: July updates include the start of annual performance reviews, upgraded paid-leave process, new case studies uploaded, and real-time leave requests via Notion portal.
 date: 2021-07-31

--- a/updates/digest/86-memo-featured-posts-smart-contract-learning-path.md
+++ b/updates/digest/86-memo-featured-posts-smart-contract-learning-path.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#86 - Memo featured posts & Smart contract learning path "
 description: Discover how console.so uses Notion for efficient blockchain development while expanding Dwarves team, sharing project case studies, and improving workflows with smart contract learning and audits.
 date: 2021-08-07

--- a/updates/digest/87-you-got-vaccinate-yet.md
+++ b/updates/digest/87-you-got-vaccinate-yet.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#87 - You got vaccinate yet?"
 description: "Discover how the V-model approach improves automation testing workflows and team collaboration in Turing Alley's Arrow Project with new members and latest updates."
 date: 2021-08-14

--- a/updates/digest/88-projects-kudos-beaverbitcoin-tokenomy.md
+++ b/updates/digest/88-projects-kudos-beaverbitcoin-tokenomy.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#88 - Projects Kudos"
 description: "Celebrate our blockchain project successes, learn about V-model testing updates, automation growth, and team ESOP news while staying safe amid Vietnam's new COVID wave."
 date: 2021-08-21

--- a/updates/digest/89-picking-up-linkedin-profiles.md
+++ b/updates/digest/89-picking-up-linkedin-profiles.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#89 - Picking up LinkedIn Profiles"
 description: Discover Basecamp Kanban updates, LinkedIn profile tips, Gitflow training for engineers, and important August cleanup and holiday schedules for your team.
 date: 2021-08-28

--- a/updates/digest/9-a-little-more-speed-for-summer.md
+++ b/updates/digest/9-a-little-more-speed-for-summer.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly digest #9: A little more speed for summer"
 short_title: "#9 A little more speed for summer"
 description: "How quickly the first half of the year speeds up before it slows down. It’s really the second half of 2024 already. Time flies when you're having a blast. Get ready to rewind and relive some of the awesome highlights from the last week, get pumped for the epic things we'll do together before this year is over."

--- a/updates/digest/90-kick-off-september.md
+++ b/updates/digest/90-kick-off-september.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#90 - Kick-off September"
 description: "Catch up on team progress, performance reviews, and plans for growth with updates on Brainery contributors and August achievements in this week's team newsletter."
 date: 2021-09-04

--- a/updates/digest/91-cypherarts-pod-town.md
+++ b/updates/digest/91-cypherarts-pod-town.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#91 - CypherArts & Pod Town"
 description: Open Fabric is building an open commerce network for seamless online payments, while actively hiring fullstack, frontend, mobile, and QA talents to grow their blockchain-based projects.
 date: 2021-09-11

--- a/updates/digest/92-more-dwarves-in-the-brain-team.md
+++ b/updates/digest/92-more-dwarves-in-the-brain-team.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#92 - More Dwarves in the Brain team"
 description: Join our expanding team exploring SaaS, Blockchain, Web3, and DeFi topics, plus discover NFT artist stories and register for the Virtual WeBuild Day event.
 date: 2021-09-18

--- a/updates/digest/93-labour-contract-renewal.md
+++ b/updates/digest/93-labour-contract-renewal.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#93 - Labour Contract Renewal"
 description: Renew your contract with Turing Alley LLC by Oct 1, learn about new salary and resignation terms, and join the October all-hands meeting and Mid-Autumn airdrop event.
 date: 2021-09-25

--- a/updates/digest/94-september-changelog.md
+++ b/updates/digest/94-september-changelog.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#94 - September Changelog"
 description: Discover the latest team updates, project progress, and new hires from our September All Hands meeting and monthly client update.
 date: 2021-10-04

--- a/updates/digest/95-social-insurance-support.md
+++ b/updates/digest/95-social-insurance-support.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#95 - Social Insurance Support"
 description: Get the latest updates on social insurance payments, new team member Ngoc, CyberNeko launch success, and Virtual WeBuild Day highlights.
 date: 2021-10-09

--- a/updates/digest/96-collect-your-insurance-card.md
+++ b/updates/digest/96-collect-your-insurance-card.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#96 - Collect Your Insurance card"
 description: Collect your Bao Viet insurance card at HaDo office by contacting Van, meet new Backend and Fullstack Engineers joining the team, and celebrate National Woman Day gifts.
 date: 2021-10-16

--- a/updates/digest/97-latest-of-oct.md
+++ b/updates/digest/97-latest-of-oct.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#97 - Latest of Oct"
 description: Get updates on the upcoming October All-hands Meeting and our search for a Hanoi office to grow the team by November.
 date: 2021-10-23

--- a/updates/digest/98-october-changelog-consulting-foundation-new-engineering-setup.md
+++ b/updates/digest/98-october-changelog-consulting-foundation-new-engineering-setup.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#98 - October Changelog: Consulting, Foundation & New Engineering Setup"
 description: Discover how our tech consulting, team scaling, and community efforts are driving growth with new projects, enhanced management, and expanded engineering teams.
 date: 2021-10-31

--- a/updates/digest/99-new-pm-new-blockchain-prj-new-remote-work-policy.md
+++ b/updates/digest/99-new-pm-new-blockchain-prj-new-remote-work-policy.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#99 - New PM, new Blockchain Prj & New remote-work policy"
 description: Meet our new Project Manager and Backend Lead as we launch a blockchain trading platform and resume weekly engineering meetings for better team collaboration.
 date: 2021-11-13

--- a/updates/digest/README.md
+++ b/updates/digest/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Changelog
 description: "Sign up for our newsletter to stay up-to-date on our latest news, tips, and updates. We'll deliver valuable content straight to your inbox, keeping you informed and engaged with stuff happening at Dwarves."
 date: 2023-12-11

--- a/updates/digest/august-changelog.md
+++ b/updates/digest/august-changelog.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: August changelog
 description: Discover how our team advances blockchain skills, improves project workflows with Basecamp Kanban, and grows expertise through audits, automation, and professional development.
 date: 2021-09-03

--- a/updates/digest/december-all-hands-meeting.md
+++ b/updates/digest/december-all-hands-meeting.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: December all-hands meeting
 description: Discover how our blockchain team grows with selective project focus, upgraded benefits, and remote work opportunities while embracing real deals and Web3 learning.
 date: 2022-01-07

--- a/updates/digest/digest.md
+++ b/updates/digest/digest.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Digest
 description: A collection of both our internal and external events, including the things we do with the Labs team, Consulting team, Operations, team, and the community.
 date: 2023-12-11

--- a/updates/digest/january-all-hands-meeting.md
+++ b/updates/digest/january-all-hands-meeting.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: January all-hands meeting
 description: Discover the latest team updates on performance reviews, blockchain projects, profit-sharing, flight ticket policies, and upcoming team events for 2022.
 date: 2022-01-24

--- a/updates/digest/road-to-100.md
+++ b/updates/digest/road-to-100.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Road to 100
 description: "2022 matched us with the 80th Dwarves. A notable highlight, and we're ready to have more. It's not easy to find people that has the same value. It takes true & solid seeks."
 date: 2022-08-26

--- a/updates/digest/september-changelog.md
+++ b/updates/digest/september-changelog.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: September changelog
 description: Discover how our team improves project compliance, launches new consulting projects like Open Fabric, enhances hiring processes, and develops React Toolkit and automation bots.
 date: 2021-10-01

--- a/updates/forward/! README.md
+++ b/updates/forward/! README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/2022.md
+++ b/updates/forward/2022.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Forward engineering Nov 2022
 short_title: 2022 Nov
 description: We want to demonstrate and encourage individual and organizational learning, where both gaining and sharing knowledge is prioritized, valued, and rewarded. Learning is an ongoing process that never ends in our fast-moving industry.

--- a/updates/forward/2023-03.md
+++ b/updates/forward/2023-03.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Forward engineering Mar 2023
 short_title: 2023 Mar
 description: "As we look back on the past month, we're excited to share our latest engineering report, which highlights our recent achievements, projects, and insight in March 2023."

--- a/updates/forward/2023-05.md
+++ b/updates/forward/2023-05.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Forward engineering May 2023
 short_title: 2023 May
 description: "As we look back on the past month, we're excited to share our latest engineering report, which highlights our recent achievements, projects, and insights in May 2023."

--- a/updates/forward/2023-06.md
+++ b/updates/forward/2023-06.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Forward engineering Jun 2023
 short_title: 2023 Jun
 description: "As we usher in the month of June, we embrace the ever-changing landscape of technological innovation, and focus on a central theme:LLM in Production."

--- a/updates/forward/2023-08.md
+++ b/updates/forward/2023-08.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Forward engineering Aug 2023
 short_title: 2023 Aug
 description: "Our adventure until now has been incredibly thrilling, with a strong focus on 'LLM in Production.' Now, we shift our attention to a topic that is always important and never outdated: **Fullstack Engineering**."

--- a/updates/forward/2023-10.md
+++ b/updates/forward/2023-10.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Forward engineering Oct 2023
 short_title: 2023 Oct
 description: "As we step into the exciting opportunities of October, we are at a crucial point in the ever-changing world of technology. Our adventure until now has been for the most part very exciting, with a strong focus on 'Full-stack engineering’ Now, we shift our attention to a topic that is prolific and always true: Open-source."

--- a/updates/forward/2023-11.md
+++ b/updates/forward/2023-11.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Forward engineering Nov 2023
 short_title: 2023 Nov
 description: We have focused on revamping how we learn, familiarize, and work with tech. We are excited to announce that we have updated our Forward Engineering to better reflect the feedback and insights from our Labs team, Operations Team, and Consulting Team.

--- a/updates/forward/2023-12.md
+++ b/updates/forward/2023-12.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Forward engineering Dec 2023
 short_title: 2023 Dec
 description: We have focused on revamping how we learn, familiarize, and work with tech. We are excited to announce that we have updated our Forward Engineering to better reflect the feedback and insights from our Labs team, Operations Team, and Consulting Team.

--- a/updates/forward/2024-09.md
+++ b/updates/forward/2024-09.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Forward engineering Sep 2024
 short_title: 2024 Sep
 description: In Q3/2024 Forward Engineering, we explore new tech stacks, engineering excellence, and key trends from the tech market over the past three months, with a focus on AI. Learn about tools like Dify, LangGraph, RAG, and more as we share our experiments and insights. Whether you’re interested in AI-driven workflows or tech market trends like the surge in AI startups and hiring demand.

--- a/updates/forward/2025-02.md
+++ b/updates/forward/2025-02.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Forward engineering Feb 2025
 short_title: 2025 Feb
 description: "AI agents, talent shifts, & market dynamics: Explore tech trends in AI, blockchain, & software engineering. Discover key insights & analysis."

--- a/updates/forward/2025-05.md
+++ b/updates/forward/2025-05.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Forward engineering May 2025
 short_title: 2025 May
 description: "Our thoughts on agent-first software development, vibe coding, our latest tool experiments, and current funding and hiring trends."

--- a/updates/forward/2025-06/README.md
+++ b/updates/forward/2025-06/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Forward engineering Jun 2025
 short_title: Jun 2025
 description: "Our thoughts on agent-first software development, vibe coding, our latest tool experiments, and current funding and hiring trends."

--- a/updates/forward/Market report/2023-december.md
+++ b/updates/forward/Market report/2023-december.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Market report December 2023
 short_title: December 2023
 description: "Here are some of the few trends we are seeing across the industry, in our projects, as well as our community. This market report isn't exhaustive, at least just yet, with certain trends not yet listed such as Blockchain, data management, DevEx, etc. We see a lot of promising trends and we hope that understanding what engineers and firms are becoming more passionate about that it will help us create a foundation of ideas and knowledge."

--- a/updates/forward/Market report/2024-april.md
+++ b/updates/forward/Market report/2024-april.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Market report April 2024
 short_title: April 2024
 description: "In april’s market report, we explore the evolving landscape of Meta's Llama 3, LLM, the shift to edge computing, the new Bun 1.1, the trend of copy-pastes UI."

--- a/updates/forward/Market report/2024-august.md
+++ b/updates/forward/Market report/2024-august.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Market report August 2024
 short_title: August 2024
 description: Explore the August 2024 market report to discover how AI and LLM tools like Cursor, Claude 3.5 Sonnet, and Amazon Q are transforming software development. Learn about the shift from generative UI to generative apps, the impact of prompt caching by Anthropic, and the rise of structured outputs in AI.

--- a/updates/forward/Market report/2024-february.md
+++ b/updates/forward/Market report/2024-february.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Market report February 2024
 short_title: February 2024
 description: "This month has been a continuation of AI and an upwards trend on FinOps and CyberSecurity. On top of those domains, there has been smaller, but very notable trends on the growth of Software as a Service (SaaS) or MicroSaaS' have rebound and created significant growth for serverless services, as a means to avoid startup and initial running costs. Likewise, AI has been changing how we work and how we design systems to enrich workflows and create more naturally interactive apps."

--- a/updates/forward/Market report/2024-january.md
+++ b/updates/forward/Market report/2024-january.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Market report January 2024
 short_title: January 2024
 description: "Here are some of the few trends we are seeing across the industry, in our projects, as well as our community. This market report isn't exhaustive, at least just yet, with certain trends not yet listed such as Blockchain, data management, DevEx, etc. We see a lot of promising trends and we hope that understanding what engineers and firms are becoming more passionate about that it will help us create a foundation of ideas and knowledge."

--- a/updates/forward/Market report/2024-july.md
+++ b/updates/forward/Market report/2024-july.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Market report July 2024
 short_title: July 2024
 description: 'In July''s market report, we explore Meta''s Llama 3.1 and its competitive edge in AI, OpenAI''s fine-tuning for GPT-4o-mini, and Claude Sonnet 3.5''s rapid development improvements. We also highlight advancements in sports analytics, multilingual text-to-speech, cybersecurity challenges, and trends in software engineering, including "boring" technology and evolving programming language salaries'

--- a/updates/forward/Market report/2024-march.md
+++ b/updates/forward/Market report/2024-march.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Market report March 2024
 short_title: March 2024
 description: In this month’s market report, we explore the evolving landscape of artificial intelligence, API techniques, toolings, programming languages, and the intersection of design and engineering. Our insights shed light on the dynamic shifts and emerging trends across these domains, highlighting the advancements that are shaping the future of technology and software development.

--- a/updates/forward/Market report/2024-may.md
+++ b/updates/forward/Market report/2024-may.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Market report may 2024
 short_title: May 2024
 description: "In May's market report, we explore GPT-4o's advancements, the rising demand for veteran programmers, the transformative power of prescriptive AI, React 19's impact on network gaps, the growing complexity of GraphQL codebases, and Bend, a new parallel programming language."

--- a/updates/forward/Market report/2024-october.md
+++ b/updates/forward/Market report/2024-october.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Market report October 2024
 short_title: October 2024
 description: "Explore the October 2024 market report: chatbots as productivity essentials with future potential, AI's role despite investment bubble concerns, and Python's rise in modern tech and AI. Learn why coding tools require strong practices, why companies seek versatile engineers, and how Big Tech's job market favors senior talent, posing challenges for juniors."

--- a/updates/forward/Market report/2024-september.md
+++ b/updates/forward/Market report/2024-september.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Market report September 2024
 short_title: September 2024
 description: "In this month's market report, we've covered the hype and skepticism around OpenAI's reasoning models, the quiet rise of lightweight AI, the misuse of serverless, and the shakeup in web frameworks."

--- a/updates/forward/README.md
+++ b/updates/forward/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Forward engineering
 short_title: § Forward engineering 🔮
 description: We launch The Dwarves Tech Radar as a living asset to evaluate the adoption decision and keep the technology direction stays on track. Tech Radar is how we do R&D, how we work on self-growth and motivate continuous curiosity.

--- a/updates/forward/_template_rfc.md
+++ b/updates/forward/_template_rfc.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/_template_submission.md
+++ b/updates/forward/_template_submission.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/ai Use cases/salesforce.md
+++ b/updates/forward/ai Use cases/salesforce.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Salesforce use cases
 description: Salesforce is taking AI to the next level with large language models that make customer service smoother, sales more strategic, and insights faster. By automating routine tasks, these tools free up teams to focus on real connections with customers. The result? Happier customers, smarter sales, and big wins for businesses.
 date: 2024-11-01

--- a/updates/forward/ai Use cases/yelp.md
+++ b/updates/forward/ai Use cases/yelp.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Yelp use cases
 description: Yelp already had a machine learning platform before the big push for large language models (LLMs). Now, they’re using LLMs to level up their search and recommendation systems, making it easier for moderators and businesses to track down users. Let’s dive into how Yelp is making it work.
 date: 2024-10-18

--- a/updates/forward/ai-digest/ai-digest-01.md
+++ b/updates/forward/ai-digest/ai-digest-01.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "AI digest #1 Aider reasoning, OpenAI Realtime API, Cline - pre Claude-dev "
 description: "Stay updated on the latest in AI tools for developers with this week’s digest, featuring Cline's v2.0.0 update, OpenAI’s Realtime API, and Aider’s Architect/Editor split for enhanced coding workflows."
 date: 2024-10-25

--- a/updates/forward/ai-digest/ai-digest-02.md
+++ b/updates/forward/ai-digest/ai-digest-02.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "AI digest #2 new command Aider, OpenHands, Qwen2.5 Coder 32B, predicted output"
 description: Stay updated on the latest in AI tools for developers with this week’s digest, new command Aider, OpenHands, Qwen2.5 Coder 32B
 date: 2024-11-15

--- a/updates/forward/frontend/frontend-report-april-2025.md
+++ b/updates/forward/frontend/frontend-report-april-2025.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags:
   - frontend
   - market-report

--- a/updates/forward/frontend/frontend-report-august-2024.md
+++ b/updates/forward/frontend/frontend-report-august-2024.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Frontend report August 2024
 short_title: August 2024
 description: A comprehensive August 2024 update on key advancements in React 19, Next.js 15, and web development tools. Highlights include new async transitions, server components, SSR performance comparisons, and emerging technologies in the web development landscape

--- a/updates/forward/frontend/frontend-report-august-2025.md
+++ b/updates/forward/frontend/frontend-report-august-2025.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Frontend report August 2025
 short_title: Frontend Web Development in August 2025
 description: "August 2025 frontend developments covering React ecosystem updates, performance optimization techniques, modern web technologies, security practices, developer tooling improvements, and AI integration in frontend workflows."

--- a/updates/forward/frontend/frontend-report-february-2025.md
+++ b/updates/forward/frontend/frontend-report-february-2025.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Frontend report February 2025
 short_title: February 2025
 description: "Our February 2025 report covers what's new in frontend development - from React's move away from Create React App to Next.js improvements, browser compatibility updates, and cool new tools like React Scan. Get practical tips for better auth, faster websites, and making your sites work for everyone."

--- a/updates/forward/frontend/frontend-report-first-half-of-november-2024.md
+++ b/updates/forward/frontend/frontend-report-first-half-of-november-2024.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Frontend report first half of November 2024
 short_title: Nov 2024 (First Half)
 description: "A comprehensive update on key advancements in frontend development for the first half of November 2024, highlighting React 19's full-stack capabilities, XState for state management, Shopify's React Native migration, Next.js 15 enhancements, and the impact of container queries on responsive design."

--- a/updates/forward/frontend/frontend-report-january-2025.md
+++ b/updates/forward/frontend/frontend-report-january-2025.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Frontend report January 2025
 short_title: January 2025
 description: "This January 2025 report explores key frontend advancements, including React 19's Actions, Next.js 15.1's Deno Deploy support, and innovative tools like Transformers.js for AI. Discover trending technologies, best practices, and expert commentary shaping the future of frontend development."

--- a/updates/forward/frontend/frontend-report-july-2024.md
+++ b/updates/forward/frontend/frontend-report-july-2024.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Frontend report July 2024
 short_title: July 2024
 description: The Front-end Market Report for July 2024 gives you a snapshot of what’s happening in the world of web development. React is evolving with Server Components making waves, and Next.js continues to push the boundaries of performance. Vite is solidifying its position as a top build tool, while TypeScript and other frameworks hold steady. Whether you’re looking for the latest updates or just want to stay in the loop, this report has you covered with key trends, tools, and insights to keep you informed.

--- a/updates/forward/frontend/frontend-report-june-2025.md
+++ b/updates/forward/frontend/frontend-report-june-2025.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Frontend Report June 2025
 short_title: Frontend Web Development in June 2025 - AI Tools and Web Platform Updates
 description: "June 2025 brought significant changes to frontend web development. This report covers the widespread adoption of AI coding tools, new CSS conditional logic features, browser updates with AI integration, React Server Components in production, TypeScript's native Node.js support, and improved development workflows."

--- a/updates/forward/frontend/frontend-report-march-2025.md
+++ b/updates/forward/frontend/frontend-report-march-2025.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Frontend report March 2025
 short_title: March 2025
 description: "March 2025 brings critical frontend updates! Learn about the Next.js security exploit you must patch nows. Explore TypeScript's upcoming 10x speed boost with Corsa, React Router's game-changing middleware, and why prefetching can surprisingly slow down your site. Plus: CSS functions are finally here, new in Chrome 133, Node.js is dropping Corepack, and TanStack Start finds an official deployment home!"

--- a/updates/forward/frontend/frontend-report-october-2024.md
+++ b/updates/forward/frontend/frontend-report-october-2024.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Frontend report october 2024
 short_title: October 2024
 description: This month’s newsletter highlights React’s new compiler beta, key updates from Next.js Conf 2024, and industry shifts toward full-stack roles and modern CSS. AI-driven tools like GitHub Copilot and Project IDX are further advancing development workflows.

--- a/updates/forward/frontend/frontend-report-second-half-of-november-2024.md
+++ b/updates/forward/frontend/frontend-report-second-half-of-november-2024.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Frontend report second half of November 2024
 short_title: Nov 2024 (Second Half)
 description: A second half of November 2024 frontend roundup featuring React Router v7, Tailwind CSS v4 Beta, and Vite 6.0. Explore tools like Next Cloudinary, Extism, and SmarkForm, plus JavaScript Symbols, and new CSS strategies.

--- a/updates/forward/frontend/frontend-report-september-2024.md
+++ b/updates/forward/frontend/frontend-report-september-2024.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Frontend report September 2024
 short_title: September 2024
 description: "This roundup highlights the latest in React and Next.js, including Server Functions, the React 19 compiler, and self-hosting with OpenNext. Find tips on lazy loading, CSS Grid, JavaScript's evolution, plus new tools and expert insights."

--- a/updates/forward/market-commentary/2024-13th-dec.md
+++ b/updates/forward/market-commentary/2024-13th-dec.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly consulting snapshot #1: Gemini 2.0, OpenAI’s Sora, a16z’s predictions"
 short_title: "#1 Gemini 2.0, OpenAI’s Sora,  a16z’s Predictions"
 description: An exploration of key advancements in AI, quantum computing, and emerging technologies reshaping consulting opportunities.

--- a/updates/forward/market-commentary/2024-27th-dec.md
+++ b/updates/forward/market-commentary/2024-27th-dec.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly consulting snapshot #2: AI talent wars, OpenAI’s new models, Hyperliquid’s rise"
 short_title: "#2 AI Talent Wars, OpenAI’s New Models, Hyperliquid"
 description: Key trends in AI, blockchain, and productivity hacks shaping the consulting space this week.

--- a/updates/forward/market-commentary/2025-10th-jan.md
+++ b/updates/forward/market-commentary/2025-10th-jan.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly consulting snapshot #4: AI supercomputers, mini AI PCs, Worldcoin expansion, and SEA VC"
 short_title: "#4 AI Supercomputers, Mini AI PCs, SEA VC"
 description: Showcasing AI breakthroughs, expanding Worldcoin, and driving SEA investments

--- a/updates/forward/market-commentary/2025-14th-feb.md
+++ b/updates/forward/market-commentary/2025-14th-feb.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly consulting snapshot #7: 10x AI cost reduction, Lyft’s 2026 robotaxi milestone, and Solana ETF buzz"
 short_title: "#7: 10x AI Cost Reduction, Lyft’s 2026 Robotaxi Milestone, and Solana ETF Buzz"
 description: 10x AI Cost Reduction, Lyft’s 2026 Robotaxi Milestone, and Solana ETF Buzz

--- a/updates/forward/market-commentary/2025-17th-jan.md
+++ b/updates/forward/market-commentary/2025-17th-jan.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly consulting snapshot #5: VC trends, blockchain breakthroughs, and AI innovations"
 short_title: "#5 VC Trends, Blockchain Breakthroughs, and AI Innovations"
 description: Showcasing VC Trends, Blockchain Breakthroughs, and AI Innovations

--- a/updates/forward/market-commentary/2025-21th-feb.md
+++ b/updates/forward/market-commentary/2025-21th-feb.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly consulting snapshot #8: R1 1776 goes open-source, Cardex gets hacked, and Grok-3 debuts"
 short_title: "#8: R1 1776 Goes Open-Source, Cardex Gets Hacked, and Grok-3 Debuts"
 description: R1 1776 Goes Open-Source, Cardex Gets Hacked, and Grok-3 Debuts

--- a/updates/forward/market-commentary/2025-28th-feb.md
+++ b/updates/forward/market-commentary/2025-28th-feb.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly consulting snapshot #9: Bybit loses $1.5B in hack, Claude 3.7 Sonnet drops, and OpenArt designs characters"
 short_title: "#9: Bybit Loses $1.5B in Hack, Claude 3.7 Sonnet Drops, and OpenArt Designs Characters"
 description: Bybit Loses $1.5B in Hack, Claude 3.7 Sonnet Drops, and OpenArt Designs Characters

--- a/updates/forward/market-commentary/2025-3rd-jan.md
+++ b/updates/forward/market-commentary/2025-3rd-jan.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly consulting snapshot #3: AI’s ubiquity at CES, Wall Street’s AI boom, and blockchain innovations"
 short_title: "#3 AI at CES, Wall Street Boom, Blockchain Trends"
 description: "Explore the impact of AI at CES 2025, Wall Street's AI-driven surge, and the fusion of blockchain and AI in emerging projects."

--- a/updates/forward/market-commentary/2025-7th-feb.md
+++ b/updates/forward/market-commentary/2025-7th-feb.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Weekly consulting snapshot #6: Trending products, DeepSeek wave, and Ethereum predictions"
 short_title: "#6 Trending Products, DeepSeek Wave, and Ethereum Predictions"
 description: Trending Products, DeepSeek Wave, and Ethereum Predictions

--- a/updates/forward/market-commentary/echelon-x-singapore-2024-where-innovations-meet-inspiration.md
+++ b/updates/forward/market-commentary/echelon-x-singapore-2024-where-innovations-meet-inspiration.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Echelon X Singapore 2024: Where innovations meet inspiration"
 description: This year’s Echelon X in Singapore was a bustling hub of innovation, bringing together around 10,000 participants. Along with visiting SPGroup, our team also attended Echelon X to have a better understanding of how the tech and startup ecosystem is heading.
 date: 2024-06-05

--- a/updates/forward/market-commentary/event-takeaways-1st.md
+++ b/updates/forward/market-commentary/event-takeaways-1st.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Talks and takeaways from the scene: part 1"
 short_title: 1st Talks and Takeaways
 description: Talks and Takeaways from the Scene Part 1

--- a/updates/forward/market-commentary/event-takeaways-2nd.md
+++ b/updates/forward/market-commentary/event-takeaways-2nd.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Talks and takeaways from the scene: part 2"
 short_title: 2nd Talks and Takeaways
 description: Talks and Takeaways from the Scene Part 2

--- a/updates/forward/market-commentary/event-takeaways-3rd.md
+++ b/updates/forward/market-commentary/event-takeaways-3rd.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Talks and takeaways from the scene part 3: Three Crypto Events, One Reality Check"
 short_title: 3rd Talks and Takeaways
 description: Talks and Takeaways from the Scene Part 3

--- a/updates/forward/market-commentary/vietnam-tech-ecosystem-report.md
+++ b/updates/forward/market-commentary/vietnam-tech-ecosystem-report.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Vietnam tech ecosystem 2024 report
 description: "The 2024 Vietnam Tech Market Report highlights Vietnam's resilient tech scene, ranking third in Southeast Asia despite a 17% drop in investments. With a booming digital economy expected to reach $43 billion by 2025, the report covers key trends, major players, and new legal updates driving innovation."
 date: 2024-07-11

--- a/updates/forward/product-design/UI History.md
+++ b/updates/forward/product-design/UI History.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: 2022-08-05

--- a/updates/forward/product-design/What Screens Want.md
+++ b/updates/forward/product-design/What Screens Want.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: 2022-06-28

--- a/updates/forward/product-design/product-design-commentary-20240927.md
+++ b/updates/forward/product-design/product-design-commentary-20240927.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Product design commentary #1: New technologies changing UX/UI and product design"
 description: "New tools are changing how we design products. In the first edition, we look at voice controls, mixed reality, reusable design parts, and smart helpers. See how they're being used, what's popular, and why designers should care. Learn to make things that are easier and better to use."
 date: 2024-09-30

--- a/updates/forward/product-design/product-design-commentary-20241004.md
+++ b/updates/forward/product-design/product-design-commentary-20241004.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Product design commentary #2: Unpacking the sparkles icon and AI onboarding challenges"
 description: In this second edition, we explore the use of the Sparkle (✨) icon for AI-driven features and the common confusion it creates for users. It covers best practices for designing effective onboarding for AI tools, highlighting the importance of clear communication, contextual help, and easy-to-follow tutorials to ensure a smooth user experience. By focusing on these elements, designers can enhance user understanding and engagement with AI features.
 date: 2024-10-07

--- a/updates/forward/product-design/product-design-commentary-20241011.md
+++ b/updates/forward/product-design/product-design-commentary-20241011.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Product design commentary #3: The art of prompting in AI-human interaction"
 description: In this third edition, we delve into the art of prompting in AI-human interaction. We explore the evolution of communication between humans and machines, focusing on the crucial role of UX designers in crafting effective prompts for large language models. The commentary covers the importance of context, system prompting techniques, and structured frameworks for prompting, highlighting how these elements shape the future of human-AI interactions and user experiences.
 date: 2024-10-14

--- a/updates/forward/product-design/product-design-commentary-20241018.md
+++ b/updates/forward/product-design/product-design-commentary-20241018.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Product design commentary #4: Generative AI UX design patterns"
 description: This fourth edition looks at how Generative AI fits into digital systems. We examine the connections between AI and other parts of a system, focusing on scope, space, and function. Learn how these connections affect the way we design AI features and make them easy to use. Get practical tips on adding AI to your products in ways that make sense for users.
 date: 2024-10-22

--- a/updates/forward/product-design/product-design-commentary-20241101.md
+++ b/updates/forward/product-design/product-design-commentary-20241101.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Product design commentary #5: Figma to SwiftUI (functional code) with Claude AI"
 description: This article provides a guide on using Claude AI to build user interfaces in SwiftUI, transforming Figma designs into complete, production-ready code. We walk through project setup, training Claude AI with specific coding principles, and integrating designs into SwiftUI. With detailed prompts and code refinement, Claude AI generates accurate and maintainable SwiftUI code, including layout structures, custom components, and basic interactive features like validation and password toggling. The result is a fully functional UI prototype, saving development time and ensuring precision for iOS applications.
 date: 2024-11-07

--- a/updates/forward/product-design/product-design-commentary-20241115.md
+++ b/updates/forward/product-design/product-design-commentary-20241115.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Product design commentary #6: AI in design - cool ideas and how to make them happen"
 description: Artificial Intelligence (AI) brings boundless opportunities to enhance both user experience and daily life. While foundational technologies often seem under the purview of data scientists and engineers, designers play a crucial role in bridging the gap between user needs and emerging technologies. This article explores the role of UX and how to determine which user problems are best solved with AI while assessing their effectiveness.
 date: 2024-11-21

--- a/updates/forward/product-design/product-design-commentary-20241122.md
+++ b/updates/forward/product-design/product-design-commentary-20241122.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Product design commentary #7: Hyper-personalization - how AI improves user experience personalization"
 description: "Hyper-personalization represents the future of product development, delivering personalized experiences that adapt to each user's needs. In this model, everyone will have their own version of the internet, shaped by AI interfaces that understand their preferences, goals, and personal context."
 date: 2024-11-28

--- a/updates/forward/vol-01/README.md
+++ b/updates/forward/vol-01/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/aarrr/README.md
+++ b/updates/forward/vol-01/aarrr/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/applied-security-basic/docs/blockchain.md
+++ b/updates/forward/vol-01/applied-security-basic/docs/blockchain.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/applied-security-basic/docs/ssh.md
+++ b/updates/forward/vol-01/applied-security-basic/docs/ssh.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/applied-security-basic/docs/ssl.md
+++ b/updates/forward/vol-01/applied-security-basic/docs/ssl.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/applied-security-basic/rfc.md
+++ b/updates/forward/vol-01/applied-security-basic/rfc.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/blockchain-for-designer/README.md
+++ b/updates/forward/vol-01/blockchain-for-designer/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/gestalt-principle/README.md
+++ b/updates/forward/vol-01/gestalt-principle/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/go-concurrency/README.md
+++ b/updates/forward/vol-01/go-concurrency/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/istio.md
+++ b/updates/forward/vol-01/istio.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: New member
 description: null
 date: 2025-04-03

--- a/updates/forward/vol-01/pwa/docs/slide.md
+++ b/updates/forward/vol-01/pwa/docs/slide.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/pwa/rfc.md
+++ b/updates/forward/vol-01/pwa/rfc.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/pwa/src/awesome-pwa/README.md
+++ b/updates/forward/vol-01/pwa/src/awesome-pwa/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/remote-ux-testing-casestudy/README.md
+++ b/updates/forward/vol-01/remote-ux-testing-casestudy/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/software-reuse/README.md
+++ b/updates/forward/vol-01/software-reuse/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/software-reuse/RFC.md
+++ b/updates/forward/vol-01/software-reuse/RFC.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/swift-ui/README.md
+++ b/updates/forward/vol-01/swift-ui/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/swift-ui/RFC.md
+++ b/updates/forward/vol-01/swift-ui/RFC.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/swift-ui/slide/slide.md
+++ b/updates/forward/vol-01/swift-ui/slide/slide.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/README.md
+++ b/updates/forward/vol-01/terminal-assistant/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/rfc.md
+++ b/updates/forward/vol-01/terminal-assistant/rfc.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/slide/slide.md
+++ b/updates/forward/vol-01/terminal-assistant/slide/slide.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/README.md
+++ b/updates/forward/vol-01/terminal-assistant/src/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/DavidBelicza/TextRank/README.md
+++ b/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/DavidBelicza/TextRank/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/inconshreveable/mousetrap/README.md
+++ b/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/inconshreveable/mousetrap/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/jaytaylor/html2text/README.md
+++ b/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/jaytaylor/html2text/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/mattn/go-runewidth/README.md
+++ b/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/mattn/go-runewidth/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/olekukonko/tablewriter/LICENSE.md
+++ b/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/olekukonko/tablewriter/LICENSE.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/olekukonko/tablewriter/README.md
+++ b/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/olekukonko/tablewriter/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/sahilm/fuzzy/CONTRIBUTING.md
+++ b/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/sahilm/fuzzy/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/sahilm/fuzzy/README.md
+++ b/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/sahilm/fuzzy/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/spf13/cobra/README.md
+++ b/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/spf13/cobra/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/spf13/cobra/bash_completions.md
+++ b/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/spf13/cobra/bash_completions.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/spf13/cobra/powershell_completions.md
+++ b/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/spf13/cobra/powershell_completions.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/spf13/cobra/zsh_completions.md
+++ b/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/spf13/cobra/zsh_completions.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/spf13/pflag/README.md
+++ b/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/spf13/pflag/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/ssor/bom/README.md
+++ b/updates/forward/vol-01/terminal-assistant/src/vendor/github.com/ssor/bom/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/three-audio-visualizer/README.md
+++ b/updates/forward/vol-01/three-audio-visualizer/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/three-audio-visualizer/docs/AudioAnalysing.md
+++ b/updates/forward/vol-01/three-audio-visualizer/docs/AudioAnalysing.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/three-audio-visualizer/docs/BasicThreeJS.md
+++ b/updates/forward/vol-01/three-audio-visualizer/docs/BasicThreeJS.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/three-audio-visualizer/rfc.md
+++ b/updates/forward/vol-01/three-audio-visualizer/rfc.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/wasm/README.md
+++ b/updates/forward/vol-01/wasm/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/wasm/rfc.md
+++ b/updates/forward/vol-01/wasm/rfc.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/wasm/wasm-asteroids/README.md
+++ b/updates/forward/vol-01/wasm/wasm-asteroids/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/xpc-service/README.md
+++ b/updates/forward/vol-01/xpc-service/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/xpc-service/RFC.md
+++ b/updates/forward/vol-01/xpc-service/RFC.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-01/xpc-service/daemon-and-services.md
+++ b/updates/forward/vol-01/xpc-service/daemon-and-services.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-02/README.md
+++ b/updates/forward/vol-02/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-02/domain-insight-research/README.md
+++ b/updates/forward/vol-02/domain-insight-research/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-02/webflow/README.md
+++ b/updates/forward/vol-02/webflow/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-03/README.md
+++ b/updates/forward/vol-03/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-03/argoCD.md
+++ b/updates/forward/vol-03/argoCD.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-03/k6.md
+++ b/updates/forward/vol-03/k6.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-03/nocode.md
+++ b/updates/forward/vol-03/nocode.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-03/preact.md
+++ b/updates/forward/vol-03/preact.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/vol-03/testlink.md
+++ b/updates/forward/vol-03/testlink.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: null
 description: null
 date: null

--- a/updates/forward/volume-01.md
+++ b/updates/forward/volume-01.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Dwarves tech radar volume 01
 short_title: Tech Radar Volume 01
 description: For this edition, the theme is to get the whole team used to the concept of a central knowledge base, every study to expand our view to the tech scene counts. The design team also has a place to contribute and discuss their practices.

--- a/updates/forward/volume-02.md
+++ b/updates/forward/volume-02.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Dwarves tech radar volume 02
 short_title: Tech Radar Volume 02
 description: Dwarves Tech Radar v2 contains the practices to simplify the workflow, new techniques/ approach methods to upgrade our current standards and expand the domain knowledge.

--- a/updates/forward/volume-03.md
+++ b/updates/forward/volume-03.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Dwarves tech radar volume 03
 short_title: Tech Radar Volume 03
 description: "In short, this 3rd volume is all about one thing: Trial"

--- a/updates/labs-digest/01.md
+++ b/updates/labs-digest/01.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Labs weekly catchup #1"
 description: Our first weekly catchup. We organize an agenda the day beforehand and consolidate our findings, notable research progress, possibly new tech, insight or technique everyone should know.
 date: 2023-12-06

--- a/updates/labs-digest/02.md
+++ b/updates/labs-digest/02.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Labs weekly catchup #2"
 description: Our second weekly catchup. We organize an agenda the day beforehand and consolidate our findings, notable research progress, possibly new tech, insight or technique everyone should know.
 date: 2023-12-14

--- a/updates/labs-digest/03.md
+++ b/updates/labs-digest/03.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Labs weekly catchup #3"
 description: Our third weekly catchup. We organize an agenda the day beforehand and consolidate our findings, notable research progress, possibly new tech, insight or technique everyone should know.
 date: 2023-12-21

--- a/updates/labs-digest/04.md
+++ b/updates/labs-digest/04.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Labs weekly catchup #4"
 description: Our fourth weekly catchup. We organize an agenda the day beforehand and consolidate our findings, notable research progress, possibly new tech, insight or technique everyone should know.
 date: 2023-12-28

--- a/updates/labs-digest/05.md
+++ b/updates/labs-digest/05.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "Labs weekly catchup #5"
 description: Our fifth weekly catchup to kick off the new year! We organize an agenda the day beforehand and consolidate our findings, notable research progress, possibly new tech, insight or technique everyone should know.
 date: 2024-01-03

--- a/updates/wala/001-43-factory.md
+++ b/updates/wala/001-43-factory.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#1 Coffee craftsmanship lessons for software engineering"
 short_title: 43 Factory
 description: Our visit to 43 Factory coffee shop in Danang revealed surprising parallels between coffee craftsmanship and software engineering. We discovered valuable insights about talent management, quality delivery, and continuous learning that directly apply to our tech practices.

--- a/updates/wala/002-dzs-media.md
+++ b/updates/wala/002-dzs-media.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#2 Film production lessons for software engineering"
 short_title: DZS Media
 description: Our visit to DZS Media revealed surprising parallels between film production and software development. Their meticulous planning, focus on getting things right the first time, and expertise-driven approach offers valuable insights for our engineering practices.

--- a/updates/wala/003-sp-group.md
+++ b/updates/wala/003-sp-group.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#3 Digital transformation insights from the energy sector"
 short_title: SP Group
 description: Our visit to SP Group offered valuable perspectives on enterprise digital transformation challenges. We learned that successful transformation depends more on people and organizational culture than technology, while strong partnerships require treating external teams as part of your own.

--- a/updates/wala/004-momby.md
+++ b/updates/wala/004-momby.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: "#4 Transforming healthcare with technology"
 short_title: Momby
 description: null

--- a/updates/wala/README.md
+++ b/updates/wala/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: WALA
 short_title: § WALA 🍭
 description: null


### PR DESCRIPTION
Demotes the `updates/` archive subtree from the memo site by adding `draft: true` to each note's YAML frontmatter. The memo app now honors `draft:true` and un-publishes those pages, so this hides the archive from the site **without deleting anything**. Scope is limited to `updates/`; the rest of the brainery repo is untouched.

Part of the dfoundation **memo-extraction Phase 3** (sub-goal 06b: demote lookup/log notes).

**Demote-never-delete.** Nothing was deleted, moved, or renamed. Each changed file gains exactly one line (`draft: true`) immediately after its opening `---`. Files that had no frontmatter were left untouched; files that already had a `draft:` key were skipped (idempotent). The full file list stays in git history and can be re-published by flipping the flag.

- Files flagged (under `updates/`): **495**
- Skipped (no frontmatter): 18
- Skipped (already had `draft:`): 2
- Deletions / renames: **0** (diff is purely +1 line per file)

Untracked local WIP and out-of-scope changes were left untouched and are not part of this PR.