### PR TITLE
chore(ci): manual-only trigger, no auto-run on push/PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,7 @@
 name: Dispatch Workflow
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   dispatch:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -4,22 +4,7 @@ name: Markdown-lint Check
 # Runs markdown linting using script from: https://memo.d.foundation/tools/ci-lint.js
 
 on:
-  push:
-    branches:
-      - main
-      - master
-    paths:
-      - '**/*.md'
-      - '**/*.mdx'
-  pull_request:
-    branches:
-      - main
-      - master
-    paths:
-      - '**/*.md'
-      - '**/*.mdx'
-
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch: # Manual trigger only
 
 concurrency:
   group: ${{ github.repository }}-linting-workflow


### PR DESCRIPTION
## Why
Org-wide policy change: no CI/build/deploy workflow should auto-run on push or PR anymore, only on manual `workflow_dispatch`. Triggered by dwarvesf/foundation-workers hitting 75% of its monthly Actions budget from one workflow that ran an expensive step unconditionally on every push (dwarvesf/foundation-workers#381).

## What changed
- `.github/workflows/main.yml`
- `.github/workflows/markdown-lint.yml`

## Not changed
Scheduled/cron jobs, PR-preview deploy/cleanup pairs, and near-zero-cost event bots (auto-assign, Discord notifications) in this repo, if any, are untouched.
