### PR TITLE
chore: remove opensource submodule tier, replace with a plain index

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,10 +14,6 @@
 	path = careers
 	url = git@github.com:dwarvesf/WeAreHiring.git
 	branch = master
-[submodule "opensource"]
-	path = opensource
-	url = git@github.com:dwarvesf/opensource.git
-	branch = main
 [submodule "radar"]
 	path = radar
 	url = git@github.com:dwarvesf/radar.git

--- a/opensource/README.md
+++ b/opensource/README.md
@@ -1,0 +1,89 @@
+---
+title: ☀️ Open source
+date: 2024-10-11
+description: 'How we support, contribute to, and reward open source development in our community'
+authors:
+  - zlatanpham
+  - monotykamary
+tags:
+  - open-source
+  - community
+---
+
+So much of the software we rely on every day is built on open source projects. We believe wholeheartedly that embracing open source makes our products the best they can be.
+
+For us, open source isn't just about the end result, it's about the journey. It's about connecting with a wider community of builders and creators. We take pride not only in what we build, but how we build it, and we want to share that process with you. We appreciate the elegance of well-crafted code and know we'll learn tremendously from community contributions along the way.
+
+That's why supporting open source contributors and makers is central to our mission. We provide this support through community recognition, collaboration opportunities, and financial rewards.
+
+## The open source work we value
+
+These open source projects particularly align with our mission:
+
+- **Libraries:** Utilities that let us focus on building great products
+- **Boilerplates:** Templates that give our projects a running start
+- **Workflow tools:** Automation that helps maintain our development flow
+- **Team experiments:** Code that helps us test new possibilities
+- **Team OSS:** Open source products built under the Dwarves banner
+- **Products we use:** Open source tools the Dwarves team values daily
+
+## Why ownership matters
+
+We've found that a sense of ownership is crucial to creating quality software. We naturally invest more care into things we own and will often dedicate personal time to nurture them. Software development follows this same principle.
+
+For the open source projects we support, we encourage you to host them under your own name, unless it's an official Dwarves-driven project. If you'd like our community to recognize your contributions:
+
+- **Add [our badge](https://github.com/dwarvesf/badge)** to show your OSS is recognized by the Dwarves community
+- **Get credit** by submitting your work to the Dwarves open source hall of fame below
+
+If your open source project gains traction, we're happy to help with launch and distribution to our community.
+
+## How we reward contributors
+
+Too often, the dedicated maintainers behind essential open source projects go uncompensated. We're working to change that by offering meaningful rewards:
+
+- **Pull requests to open source projects:**
+  - 10 ICY for small improvements or bug fixes
+  - 20-50 ICY for new features or ideas
+  - 50-150 ICY for major releases or architectural work
+- **Publications:** 20-50 ICY for write-ups on tech trends or state-of-the-art development
+- **OSS products:** 50-250 ICY based on the product's impact on Dwarves members, plus 50-100 ICY/month for active maintainers who continue to advance the product
+
+## Our hall of fame
+
+This page celebrates the contributions of Dwarves community members to the open source ecosystem. We appreciate the time and effort our members invest in building projects and contributing to others.
+
+### Projects by our community
+
+The following table showcases open source projects created by Dwarves community members. We invite you to explore and contribute to these projects!
+
+| Project Name | Description | Maintainer |
+| ------------ | ----------- | ----------- |
+| [Hidden Bar for MacOS](https://github.com/dwarvesf/hidden) | An ultra-light MacOS utility that helps hide menu bar icons | [phucledien](https://github.com/phucledien) |
+| [Mochi UI](https://github.com/consolelabs/mochi-ui) | Beautiful and accessible React UI library for building web3 applications | [thanh](https://github.com/zlatanpham) |
+| [LLM Hosting](https://github.com/dwarvesf/llm-hosting/) | Managing server processes for embeddings using the Infinity Embedding model or LLMs with an OpenAI-compatible vLLM server (archived, read-only) | [monotykamary](https://github.com/monotykamary) |
+| [GitHub Agent](https://github.com/dwarvesf/github-agent) | Agentic GitHub workflows with reminders, PR monitoring, and progress tracking (archived, read-only) | dwarvesf |
+| [Devpod Provider Paperspace](https://github.com/dwarvesf/devpod-provider-paperspace) | A Paperspace provider for DevPod | [monotykamary](https://github.com/monotykamary) |
+| [NextJS Boilerplate](https://github.com/dwarvesf/nextjs-boilerplate) | Opinionated React template for building web applications at scale | [thanh](https://github.com/zlatanpham) |
+| [Go API Boilerplate](https://github.com/dwarvesf/go-api) | Go boilerplate streamlines new projects with a predefined structure and base code | [hieuphq](https://github.com/hieuphq) |
+
+> **Note:** If you're a Dwarves community member and you've created an open source project, please submit a PR to add it to the list!
+
+### Community contributions
+
+Here are the pull requests made by Dwarves community members to various open source projects, making a difference in the wider ecosystem.
+
+| PR Title | Project | Contributor |
+| -------- | ------- | ----------- |
+| [Add clickhouse support](https://github.com/pressly/goose/pull/208) | [goose](https://github.com/pressly/goose) | [huynguyenh](https://github.com/huynguyenh) |
+| [Fix undefined response from get-github-info call](https://github.com/changesets/changesets/pull/510)          | [changesets](https://github.com/changesets/changesets)         | [tuanddd](https://github.com/tuanddd)           |
+| [Add typescript example for agent simulation evaluation](https://github.com/langchain-ai/langgraphjs/pull/467) | [langgraphjs](https://github.com/langchain-ai/langgraphjs)     | [nnhuyhoang](https://github.com/nnhuyhoang)     |
+| [Update env configuration for development](https://github.com/kinopio-club/kinopio-apple/pull/1)               | [kinopio-apple](https://github.com/kinopio-club/kinopio-apple) | [phucledien](https://github.com/phucledien)     |
+| [Add OpenAI's new structured output API](https://github.com/brainlid/langchain/pull/180)                       | [brainlid/langchain](https://github.com/brainlid/langchain)    | [monotykamary](https://github.com/monotykamary) |
+| [Fix default to False if stream is unavailable](https://github.com/open-webui/open-webui/pull/6261)            | [open-webui](https://github.com/open-webui)                    | [monotykamary](https://github.com/monotykamary) |
+
+## Join the movement
+
+At its core, open source is about the people behind the code. It's about a community coming together to build software that makes all our lives better. We want to recognize, support, and reward you for your contributions to this vital ecosystem.
+
+> **Note:** Have you contributed to an open source project? Submit a PR to include your contribution in our list!


### PR DESCRIPTION
## Problem

`opensource` is a submodule pointing to `dwarvesf/opensource`, which itself carries 12 further nested submodule gitlinks (code repos, not content). That extra layer of checkout depth previously froze `memo.d.foundation`'s "Update submodules" job for weeks (2026-06-23 to 2026-07-19) when three of those nested pointers went dead; `dwarvesf/opensource#1` fixed that specific outage by dropping the three 404/redirect entries (`dotfiles`, `yggdrasil`, `glod`).

This PR removes the `opensource` submodule tier entirely and inlines its actual content as a plain file, so brainery no longer depends on a second hop of submodule resolution for this page.

## Re-verification (today, 2026-08-12)

An earlier note claimed PR #1 had already trimmed the nested submodules down to 4 live (`hidden`, `github-agent`, `llm-hosting`, `mochi-ui`) and archived 8 dead ones. **That's not what PR #1 did**, its own diff only removes 3 stanzas (`dotfiles`, `yggdrasil`, `glod`), all three already fully 404/gone. The other 12 entries were untouched and remain in `dwarvesf/opensource`'s `.gitmodules` today.

I re-checked all 12 current entries directly (`gh api repos/<org>/<repo>/commits?per_page=1` for existence, `gh api repos/<org>/<repo>` for archived/private status):

| Submodule | Target repo | Commits API | Archived | Private | Verdict |
|---|---|---|---|---|---|
| hidden | dwarvesf/hidden | resolves | no | no | **live** |
| mochi-ui | consolelabs/mochi-ui | resolves | no | no | **live** |
| github-agent | dwarvesf/github-agent | resolves | **yes** | no | archived, still public |
| llm-hosting | dwarvesf/llm-hosting | resolves | **yes** | no | archived, still public |
| blurred | dwarvesf/blurred | resolves | **yes** | **yes** | archived + private (link 404s for visitors) |
| react-toolkit | dwarvesf/react-toolkit | resolves | **yes** | **yes** | archived + private (link 404s for visitors) |
| session-buddy | dwarvesf/session-buddy | resolves | **yes** | **yes** | archived + private |
| go-threads | dwarvesf/go-threads | resolves | **yes** | **yes** | archived + private |
| code-viewer | dwarvesf/CodeViewer | resolves | **yes** | **yes** | archived + private |
| micro-sniff | dwarvesf/micro-sniff | resolves | **yes** | **yes** | archived + private |
| auto-dnd | dwarvesf/auto-dnd | resolves | **yes** | **yes** | archived + private |
| sudo-fn-macos | dwarvesf/sudo-fm-macos | resolves | **yes** | **yes** | archived + private |

None of the 12 are 404/gone (all resolve via the commits API), so by that literal test alone the old note's "8 dead" framing overstates it. But by GitHub's own `archived` flag, only **2 of 12** (`hidden`, `mochi-ui`) are still actively maintained; `github-agent`/`llm-hosting` are archived-but-public; the remaining 8 are archived **and** private, so their GitHub links are currently broken for any outside reader. That 2/2/8 split happens to land close to the old note's 4-live/8-dead claim, but for a different reason than the note stated (nothing here was "archived by PR #1", these repos were already in this state; PR #1 only cleared the three fully-gone pointers).

## One correction to the task's own premise

The task framing called `dwarvesf/opensource` "zero own content." That's not accurate: its `README.md` **is** the live `https://memo.d.foundation/opensource` page (confirmed via brainery's own `links.md`, which links to that exact URL), a real hall-of-fame page with a mission statement, an ICY reward structure, a community-projects table, and a PR-contributions table. So this change is not "delete a submodule that renders nothing," it's "stop resolving that page through a second submodule hop and inline it as a plain file instead," which is a meaningfully different (and safer) framing than "zero risk."

## What changed

- `git submodule deinit` + `git rm opensource`, stanza dropped from `.gitmodules`.
- Added `opensource/README.md` as a plain file (matches the existing brainery convention, every other top-level section, e.g. `culture/`, `consulting/`, `earn/`, is a plain dir with its own `README.md`, not a submodule-linked one). Content is the original opensource README, verbatim, except:
  - Reordered the hall-of-fame table to put the two confirmed-still-maintained projects (Hidden, Mochi UI) first, and labeled `llm-hosting`/`github-agent` as archived/read-only.
  - **Dropped the Blurred and React Toolkit rows**, both target repos are now private, so those links currently 404 for any site visitor. This was a genuine (if small) live-site bug this PR also happens to fix.
  - Removed the self-referential "submit a PR to `dwarvesf/opensource`" link (that repo no longer exists as the destination once this page lives inside brainery).

## Not done here / assumption inherited

I did not clone `memo.d.foundation` in this task, so I have not personally re-verified its `git-fetch.sh` `MAX_DEPTH` cap or its content-compiler's read path. The "the 12 nested code-repo submodules under `opensource/` contribute zero rendered content to the site" claim is inherited from the task's prior analysis, not something I independently confirmed against `memo.d.foundation`'s source. What I *did* independently confirm (via brainery's own `links.md`) is that `opensource/README.md` itself is the live page, that part of the "zero content" framing was simply wrong, and is corrected above.

## Follow-up (not done here)

After this merges, `memo.d.foundation`'s `vault` submodule pointer needs bumping to pick up this commit. Separate, later step.
