### PR TITLE
docs(culture): the tells, a field guide to AI writing shapes

### DIFF
--- a/culture/ai-writing-tells.md
+++ b/culture/ai-writing-tells.md
@@ -33,7 +33,11 @@ Every example above comes from a post published on this site under my name. I we
 
 None of these shapes is wrong on its own. Good essayists use all of them, and they saturate the writing models were trained on because they work: a well-placed triad satisfies, a landing sentence gives a paragraph a click of closure. The tell is density. A human writer spends these effects maybe once a page. A model reaches for one every few sentences, because each one scored well in training and nothing ever taught it to budget them. The result reads like a speech that never stops building toward an applause line.
 
-![Two abstract pages of text side by side. Rhetorical devices are marked as red dots: one dot on the human writer's page, seven on the model's.](assets/ai-writing-tells.svg)
+I counted, because the claim felt checkable. Across the older post's 130 prose sentences I tallied 37 of these devices, about 28 per 100 sentences. This post carries one. I also measured sentence lengths, expecting uniform rhythm to be the giveaway, and that one washed out: both posts vary about the same.
+
+![Bar chart of rhetorical devices per 100 sentences across five device families, high in the AI-assisted post and near zero in this one, next to two nearly identical sentence-length distributions.](assets/ai-writing-tells.svg)
+
+_Five device families, hand-counted across the two posts (quoted specimens excluded), beside the sentence-length distributions that failed to separate them._
 
 ## What we changed
 

--- a/culture/ai-writing-tells.md
+++ b/culture/ai-writing-tells.md
@@ -1,0 +1,46 @@
+---
+title: The tells
+description: AI writing gives itself away at the level of structure, not word choice. A field guide to the patterns, and the guideline change that bans them from our posts.
+date: 2026-08-13
+authors:
+  - tieubao
+tags:
+  - culture
+  - writing
+  - ai
+  - craftsmanship
+---
+
+A friend sent me a writing checklist last week. One line of instruction came with it: use this when you make the post, so it doesn't sound so load bearing.
+
+Load bearing. I knew what he meant before I opened the file. AI prose has a stressed, over-engineered quality, like every sentence was asked to hold up the paragraph above it. You feel the strain before you can name the pattern.
+
+We had been through one round of this already. A few weeks back I adopted a writing discipline based on Simplified Technical English, the controlled language that aviation maintenance manuals use: sentences under twenty words, active voice, no nominalization, a banned-word list (leverage, robust, seamless, delve). It helped. The sentences got cleaner. The posts still read like a model wrote them, and for a while I couldn't say why.
+
+The checklist answered it. Word-level rules catch word-level defects, and the thing that gives AI writing away now lives a level up, in structure.
+
+## The shapes
+
+Some examples, so this stays concrete.
+
+- **Corrective negation.** "The problem isn't the AI. The problem is thinking better tools lead to better outcomes." The not-this-but-that pivot, deployed as a reveal.
+- **The rule of three.** "Readable, maintainable, and solves real problems." Three parallel items, the third stretched a little for rhythm.
+- **Setup and payoff.** A short question, then the answer delivered as a punchline. "But three weeks later? They were completely stuck."
+- **The landing sentence.** A paragraph that ends on a tidy epigram, built to be quoted. "The difference is huge."
+- **Uniform rhythm.** Every sentence between twelve and eighteen words, forever.
+
+Every example above comes from a post published on this site under my name. I went back and reread my own writing after the checklist arrived, and it was uncomfortable. The drafts I had run through AI tooling carried these shapes in nearly every paragraph.
+
+None of these shapes is wrong on its own. Good essayists use all of them, and they saturate the writing models were trained on because they work: a well-placed triad satisfies, a landing sentence gives a paragraph a click of closure. The tell is density. A human writer spends these effects maybe once a page. A model reaches for one every few sentences, because each one scored well in training and nothing ever taught it to budget them. The result reads like a speech that never stops building toward an applause line.
+
+![Two abstract pages of text side by side. Rhetorical devices are marked as red dots: one dot on the human writer's page, seven on the model's.](assets/ai-writing-tells.svg)
+
+## What we changed
+
+The fix was unglamorous. I turned the checklist into a banned-pattern list and put it beside the word-level rules in the instructions my coding agent loads on every session. It went into the always-on layer deliberately: a style rule sitting in a file the agent may or may not open holds for exactly one session.
+
+One existing rule needed surgery. The STE discipline capped sentences at twenty words, and the cap had quietly become a meter. Everything came out the same length, which is its own tell. The cap stays, as a ceiling. Under it, sentence length is supposed to wander. Short. Then something longer that takes its time getting where it's going, because that variation is what a human hand sounds like on the page.
+
+There is a caveat taped to all of this. The ruleset fixes form. Whether the post has anything to say is a separate problem, and no checklist catches an empty idea dressed in varied sentence lengths.
+
+This post went through the list before publishing. The draft tripped twice, once on a corrective negation and once on a landing sentence, both in the section you just read. I rewrote them, and the paragraph lost nothing.

--- a/culture/ai-writing-tells.md
+++ b/culture/ai-writing-tells.md
@@ -25,7 +25,7 @@ Some examples, so this stays concrete.
 
 - **Corrective negation.** "The problem isn't the AI. The problem is thinking better tools lead to better outcomes." The not-this-but-that pivot, deployed as a reveal.
 - **The rule of three.** "Readable, maintainable, and solves real problems." Three parallel items, the third stretched a little for rhythm.
-- **Setup and payoff.** A short question, then the answer delivered as a punchline. "But three weeks later? They were completely stuck."
+- **Setup and payoff.** A short question, then the answer delivered as a punchline. "But three weeks later? They hit a tricky bug and were completely stuck."
 - **The landing sentence.** A paragraph that ends on a tidy epigram, built to be quoted. "The difference is huge."
 - **Uniform rhythm.** Every sentence between twelve and eighteen words, forever.
 
@@ -37,7 +37,7 @@ I counted, because the claim felt checkable. Across the older post's 130 prose s
 
 ![Bar chart of rhetorical devices per 100 sentences across five device families, high in the AI-assisted post and near zero in this one, next to two nearly identical sentence-length distributions.](assets/ai-writing-tells.svg)
 
-_Five device families, hand-counted across the two posts (quoted specimens excluded), beside the sentence-length distributions that failed to separate them._
+_Five device families, hand-counted across the two posts, each with a specimen quoted from the older post; beside them, the sentence-length distributions that failed to separate the texts. Prose sentences only; quoted specimens excluded from the counts._
 
 ## What we changed
 

--- a/culture/assets/ai-writing-tells.svg
+++ b/culture/assets/ai-writing-tells.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 600" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="1" stdDeviation="3" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <rect width="1000" height="600" fill="#ffffff"/>
+
+  <text x="500" y="42" text-anchor="middle" font-size="20" font-weight="700" fill="#111827">Where the tells sit on the page</text>
+  <text x="500" y="66" text-anchor="middle" font-size="12.5" fill="#6b7280">Each dot is one rhetorical device: a triad, a pivot, a landing sentence</text>
+
+  <!-- human page -->
+  <rect x="120" y="110" width="330" height="340" rx="10" fill="#ffffff" stroke="#e5e7eb" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="146" y="140" width="270" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="146" y="158" width="232" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="146" y="176" width="180" height="6" rx="3" fill="#d1d5db"/>
+
+  <rect x="146" y="202" width="265" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="146" y="220" width="205" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="146" y="238" width="272" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="146" y="256" width="120" height="6" rx="3" fill="#d1d5db"/>
+
+  <rect x="146" y="282" width="80" height="6" rx="3" fill="#d1d5db"/>
+  <circle cx="240" cy="285" r="7" fill="#f43f5e"/>
+  <rect x="254" y="282" width="150" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="146" y="300" width="260" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="146" y="318" width="196" height="6" rx="3" fill="#d1d5db"/>
+
+  <rect x="146" y="344" width="268" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="146" y="362" width="238" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="146" y="380" width="140" height="6" rx="3" fill="#d1d5db"/>
+
+  <text x="285" y="482" text-anchor="middle" font-size="15" font-weight="700" fill="#111827">human writer</text>
+  <text x="285" y="502" text-anchor="middle" font-size="12" fill="#6b7280">once a page</text>
+
+  <!-- model page -->
+  <rect x="550" y="110" width="330" height="340" rx="10" fill="#ffffff" stroke="#e5e7eb" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="576" y="140" width="110" height="6" rx="3" fill="#d1d5db"/>
+  <circle cx="700" cy="143" r="7" fill="#f43f5e"/>
+  <rect x="714" y="140" width="140" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="576" y="158" width="258" height="6" rx="3" fill="#d1d5db"/>
+  <circle cx="584" cy="179" r="7" fill="#f43f5e"/>
+  <rect x="598" y="176" width="236" height="6" rx="3" fill="#d1d5db"/>
+
+  <rect x="576" y="202" width="255" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="576" y="220" width="60" height="6" rx="3" fill="#d1d5db"/>
+  <circle cx="650" cy="223" r="7" fill="#f43f5e"/>
+  <rect x="664" y="220" width="190" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="576" y="238" width="260" height="6" rx="3" fill="#d1d5db"/>
+
+  <rect x="576" y="264" width="210" height="6" rx="3" fill="#d1d5db"/>
+  <circle cx="800" cy="267" r="7" fill="#f43f5e"/>
+  <rect x="814" y="264" width="40" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="576" y="282" width="252" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="576" y="300" width="140" height="6" rx="3" fill="#d1d5db"/>
+  <circle cx="730" cy="303" r="7" fill="#f43f5e"/>
+  <rect x="744" y="300" width="110" height="6" rx="3" fill="#d1d5db"/>
+
+  <rect x="576" y="326" width="258" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="576" y="344" width="20" height="6" rx="3" fill="#d1d5db"/>
+  <circle cx="610" cy="347" r="7" fill="#f43f5e"/>
+  <rect x="624" y="344" width="230" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="576" y="362" width="256" height="6" rx="3" fill="#d1d5db"/>
+  <rect x="576" y="380" width="230" height="6" rx="3" fill="#d1d5db"/>
+  <circle cx="820" cy="383" r="7" fill="#f43f5e"/>
+
+  <text x="715" y="482" text-anchor="middle" font-size="15" font-weight="700" fill="#111827">model</text>
+  <text x="715" y="502" text-anchor="middle" font-size="12" fill="#6b7280">every few sentences</text>
+
+  <!-- takeaway band -->
+  <rect x="150" y="540" width="700" height="34" rx="6" fill="#f9fafb" stroke="#d1d5db" stroke-width="1" stroke-dasharray="6,3"/>
+  <text x="500" y="561" text-anchor="middle" font-size="12" font-weight="600" fill="#374151">The tell is density: the same shapes, spent at different rates.</text>
+</svg>

--- a/culture/assets/ai-writing-tells.svg
+++ b/culture/assets/ai-writing-tells.svg
@@ -1,74 +1,1974 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 600" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
-  <defs>
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="1" stdDeviation="3" flood-opacity="0.08"/>
-    </filter>
-  </defs>
-
-  <rect width="1000" height="600" fill="#ffffff"/>
-
-  <text x="500" y="42" text-anchor="middle" font-size="20" font-weight="700" fill="#111827">Where the tells sit on the page</text>
-  <text x="500" y="66" text-anchor="middle" font-size="12.5" fill="#6b7280">Each dot is one rhetorical device: a triad, a pivot, a landing sentence</text>
-
-  <!-- human page -->
-  <rect x="120" y="110" width="330" height="340" rx="10" fill="#ffffff" stroke="#e5e7eb" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="146" y="140" width="270" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="146" y="158" width="232" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="146" y="176" width="180" height="6" rx="3" fill="#d1d5db"/>
-
-  <rect x="146" y="202" width="265" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="146" y="220" width="205" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="146" y="238" width="272" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="146" y="256" width="120" height="6" rx="3" fill="#d1d5db"/>
-
-  <rect x="146" y="282" width="80" height="6" rx="3" fill="#d1d5db"/>
-  <circle cx="240" cy="285" r="7" fill="#f43f5e"/>
-  <rect x="254" y="282" width="150" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="146" y="300" width="260" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="146" y="318" width="196" height="6" rx="3" fill="#d1d5db"/>
-
-  <rect x="146" y="344" width="268" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="146" y="362" width="238" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="146" y="380" width="140" height="6" rx="3" fill="#d1d5db"/>
-
-  <text x="285" y="482" text-anchor="middle" font-size="15" font-weight="700" fill="#111827">human writer</text>
-  <text x="285" y="502" text-anchor="middle" font-size="12" fill="#6b7280">once a page</text>
-
-  <!-- model page -->
-  <rect x="550" y="110" width="330" height="340" rx="10" fill="#ffffff" stroke="#e5e7eb" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="576" y="140" width="110" height="6" rx="3" fill="#d1d5db"/>
-  <circle cx="700" cy="143" r="7" fill="#f43f5e"/>
-  <rect x="714" y="140" width="140" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="576" y="158" width="258" height="6" rx="3" fill="#d1d5db"/>
-  <circle cx="584" cy="179" r="7" fill="#f43f5e"/>
-  <rect x="598" y="176" width="236" height="6" rx="3" fill="#d1d5db"/>
-
-  <rect x="576" y="202" width="255" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="576" y="220" width="60" height="6" rx="3" fill="#d1d5db"/>
-  <circle cx="650" cy="223" r="7" fill="#f43f5e"/>
-  <rect x="664" y="220" width="190" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="576" y="238" width="260" height="6" rx="3" fill="#d1d5db"/>
-
-  <rect x="576" y="264" width="210" height="6" rx="3" fill="#d1d5db"/>
-  <circle cx="800" cy="267" r="7" fill="#f43f5e"/>
-  <rect x="814" y="264" width="40" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="576" y="282" width="252" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="576" y="300" width="140" height="6" rx="3" fill="#d1d5db"/>
-  <circle cx="730" cy="303" r="7" fill="#f43f5e"/>
-  <rect x="744" y="300" width="110" height="6" rx="3" fill="#d1d5db"/>
-
-  <rect x="576" y="326" width="258" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="576" y="344" width="20" height="6" rx="3" fill="#d1d5db"/>
-  <circle cx="610" cy="347" r="7" fill="#f43f5e"/>
-  <rect x="624" y="344" width="230" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="576" y="362" width="256" height="6" rx="3" fill="#d1d5db"/>
-  <rect x="576" y="380" width="230" height="6" rx="3" fill="#d1d5db"/>
-  <circle cx="820" cy="383" r="7" fill="#f43f5e"/>
-
-  <text x="715" y="482" text-anchor="middle" font-size="15" font-weight="700" fill="#111827">model</text>
-  <text x="715" y="502" text-anchor="middle" font-size="12" fill="#6b7280">every few sentences</text>
-
-  <!-- takeaway band -->
-  <rect x="150" y="540" width="700" height="34" rx="6" fill="#f9fafb" stroke="#d1d5db" stroke-width="1" stroke-dasharray="6,3"/>
-  <text x="500" y="561" text-anchor="middle" font-size="12" font-weight="600" fill="#374151">The tell is density: the same shapes, spent at different rates.</text>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="519.668047pt" height="233.474654pt" viewBox="0 0 519.668047 233.474654" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-13T06:27:02.616660</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 233.474654 
+L 519.668047 233.474654 
+L 519.668047 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 32.588047 197.43024 
+L 295.324279 197.43024 
+L 295.324279 20.02224 
+L 32.588047 20.02224 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 44.530603 197.43024 
+L 63.598549 197.43024 
+L 63.598549 69.337821 
+L 44.530603 69.337821 
+z
+" clip-path="url(#p34fe4b285d)" style="fill: #4b5563"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 94.70941 197.43024 
+L 113.777356 197.43024 
+L 113.777356 53.326269 
+L 94.70941 53.326269 
+z
+" clip-path="url(#p34fe4b285d)" style="fill: #4b5563"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 144.888216 197.43024 
+L 163.956163 197.43024 
+L 163.956163 69.337821 
+L 144.888216 69.337821 
+z
+" clip-path="url(#p34fe4b285d)" style="fill: #4b5563"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 195.067023 197.43024 
+L 214.13497 197.43024 
+L 214.13497 101.360926 
+L 195.067023 101.360926 
+z
+" clip-path="url(#p34fe4b285d)" style="fill: #4b5563"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 245.24583 197.43024 
+L 264.313776 197.43024 
+L 264.313776 101.360926 
+L 245.24583 101.360926 
+z
+" clip-path="url(#p34fe4b285d)" style="fill: #4b5563"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 63.598549 197.43024 
+L 82.666496 197.43024 
+L 82.666496 197.43024 
+L 63.598549 197.43024 
+z
+" clip-path="url(#p34fe4b285d)" style="fill: #2563eb"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 113.777356 197.43024 
+L 132.845303 197.43024 
+L 132.845303 197.43024 
+L 113.777356 197.43024 
+z
+" clip-path="url(#p34fe4b285d)" style="fill: #2563eb"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 163.956163 197.43024 
+L 183.024109 197.43024 
+L 183.024109 197.43024 
+L 163.956163 197.43024 
+z
+" clip-path="url(#p34fe4b285d)" style="fill: #2563eb"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 214.13497 197.43024 
+L 233.202916 197.43024 
+L 233.202916 197.43024 
+L 214.13497 197.43024 
+z
+" clip-path="url(#p34fe4b285d)" style="fill: #2563eb"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 264.313776 197.43024 
+L 283.381723 197.43024 
+L 283.381723 144.058399 
+L 264.313776 144.058399 
+z
+" clip-path="url(#p34fe4b285d)" style="fill: #2563eb"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m8ca0a002df" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8ca0a002df" x="63.598549" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- corrective -->
+      <g transform="translate(45.17812 210.931827) scale(0.085 -0.085)">
+       <defs>
+        <path id="Helvetica-46" d="M 1703 3444 
+Q 2269 3444 2623 3169 
+Q 2978 2894 3050 2222 
+L 2503 2222 
+Q 2453 2531 2275 2736 
+Q 2097 2941 1703 2941 
+Q 1166 2941 934 2416 
+Q 784 2075 784 1575 
+Q 784 1072 996 728 
+Q 1209 384 1666 384 
+Q 2016 384 2220 598 
+Q 2425 813 2503 1184 
+L 3050 1184 
+Q 2956 519 2581 211 
+Q 2206 -97 1622 -97 
+Q 966 -97 575 383 
+Q 184 863 184 1581 
+Q 184 2463 612 2953 
+Q 1041 3444 1703 3444 
+z
+M 1616 3428 
+L 1616 3428 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-52" d="M 1741 363 
+Q 2300 363 2508 786 
+Q 2716 1209 2716 1728 
+Q 2716 2197 2566 2491 
+Q 2328 2953 1747 2953 
+Q 1231 2953 997 2559 
+Q 763 2166 763 1609 
+Q 763 1075 997 719 
+Q 1231 363 1741 363 
+z
+M 1763 3444 
+Q 2409 3444 2856 3012 
+Q 3303 2581 3303 1744 
+Q 3303 934 2909 406 
+Q 2516 -122 1688 -122 
+Q 997 -122 590 345 
+Q 184 813 184 1600 
+Q 184 2444 612 2944 
+Q 1041 3444 1763 3444 
+z
+M 1744 3428 
+L 1744 3428 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-55" d="M 428 3347 
+L 963 3347 
+L 963 2769 
+Q 1028 2938 1284 3180 
+Q 1541 3422 1875 3422 
+Q 1891 3422 1928 3419 
+Q 1966 3416 2056 3406 
+L 2056 2813 
+Q 2006 2822 1964 2825 
+Q 1922 2828 1872 2828 
+Q 1447 2828 1219 2554 
+Q 991 2281 991 1925 
+L 991 0 
+L 428 0 
+L 428 3347 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-48" d="M 1806 3422 
+Q 2163 3422 2497 3255 
+Q 2831 3088 3006 2822 
+Q 3175 2569 3231 2231 
+Q 3281 2000 3281 1494 
+L 828 1494 
+Q 844 984 1069 676 
+Q 1294 369 1766 369 
+Q 2206 369 2469 659 
+Q 2619 828 2681 1050 
+L 3234 1050 
+Q 3213 866 3089 639 
+Q 2966 413 2813 269 
+Q 2556 19 2178 -69 
+Q 1975 -119 1719 -119 
+Q 1094 -119 659 336 
+Q 225 791 225 1609 
+Q 225 2416 662 2919 
+Q 1100 3422 1806 3422 
+z
+M 2703 1941 
+Q 2669 2306 2544 2525 
+Q 2313 2931 1772 2931 
+Q 1384 2931 1121 2651 
+Q 859 2372 844 1941 
+L 2703 1941 
+z
+M 1753 3428 
+L 1753 3428 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-57" d="M 525 4281 
+L 1094 4281 
+L 1094 3347 
+L 1628 3347 
+L 1628 2888 
+L 1094 2888 
+L 1094 703 
+Q 1094 528 1213 469 
+Q 1278 434 1431 434 
+Q 1472 434 1519 436 
+Q 1566 438 1628 444 
+L 1628 0 
+Q 1531 -28 1426 -40 
+Q 1322 -53 1200 -53 
+Q 806 -53 665 148 
+Q 525 350 525 672 
+L 525 2888 
+L 72 2888 
+L 72 3347 
+L 525 3347 
+L 525 4281 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-4c" d="M 413 3331 
+L 984 3331 
+L 984 0 
+L 413 0 
+L 413 3331 
+z
+M 413 4591 
+L 984 4591 
+L 984 3953 
+L 413 3953 
+L 413 4591 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-59" d="M 688 3347 
+L 1581 622 
+L 2516 3347 
+L 3131 3347 
+L 1869 0 
+L 1269 0 
+L 34 3347 
+L 688 3347 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-46"/>
+       <use xlink:href="#Helvetica-52" transform="translate(50 0)"/>
+       <use xlink:href="#Helvetica-55" transform="translate(105.609375 0)"/>
+       <use xlink:href="#Helvetica-55" transform="translate(138.90625 0)"/>
+       <use xlink:href="#Helvetica-48" transform="translate(172.203125 0)"/>
+       <use xlink:href="#Helvetica-46" transform="translate(227.8125 0)"/>
+       <use xlink:href="#Helvetica-57" transform="translate(277.8125 0)"/>
+       <use xlink:href="#Helvetica-4c" transform="translate(305.59375 0)"/>
+       <use xlink:href="#Helvetica-59" transform="translate(327.8125 0)"/>
+       <use xlink:href="#Helvetica-48" transform="translate(377.8125 0)"/>
+      </g>
+      <!-- negation -->
+      <g transform="translate(47.293159 219.004337) scale(0.085 -0.085)">
+       <defs>
+        <path id="Helvetica-51" d="M 413 3347 
+L 947 3347 
+L 947 2872 
+Q 1184 3166 1450 3294 
+Q 1716 3422 2041 3422 
+Q 2753 3422 3003 2925 
+Q 3141 2653 3141 2147 
+L 3141 0 
+L 2569 0 
+L 2569 2109 
+Q 2569 2416 2478 2603 
+Q 2328 2916 1934 2916 
+Q 1734 2916 1606 2875 
+Q 1375 2806 1200 2600 
+Q 1059 2434 1017 2257 
+Q 975 2081 975 1753 
+L 975 0 
+L 413 0 
+L 413 3347 
+z
+M 1734 3428 
+L 1734 3428 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-4a" d="M 1594 3406 
+Q 1988 3406 2281 3213 
+Q 2441 3103 2606 2894 
+L 2606 3316 
+L 3125 3316 
+L 3125 272 
+Q 3125 -366 2938 -734 
+Q 2588 -1416 1616 -1416 
+Q 1075 -1416 706 -1173 
+Q 338 -931 294 -416 
+L 866 -416 
+Q 906 -641 1028 -763 
+Q 1219 -950 1628 -950 
+Q 2275 -950 2475 -494 
+Q 2594 -225 2584 466 
+Q 2416 209 2178 84 
+Q 1941 -41 1550 -41 
+Q 1006 -41 598 345 
+Q 191 731 191 1622 
+Q 191 2463 602 2934 
+Q 1013 3406 1594 3406 
+z
+M 2606 1688 
+Q 2606 2309 2350 2609 
+Q 2094 2909 1697 2909 
+Q 1103 2909 884 2353 
+Q 769 2056 769 1575 
+Q 769 1009 998 714 
+Q 1228 419 1616 419 
+Q 2222 419 2469 966 
+Q 2606 1275 2606 1688 
+z
+M 1659 3428 
+L 1659 3428 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-44" d="M 844 891 
+Q 844 647 1022 506 
+Q 1200 366 1444 366 
+Q 1741 366 2019 503 
+Q 2488 731 2488 1250 
+L 2488 1703 
+Q 2384 1638 2221 1594 
+Q 2059 1550 1903 1531 
+L 1563 1488 
+Q 1256 1447 1103 1359 
+Q 844 1213 844 891 
+z
+M 2206 2028 
+Q 2400 2053 2466 2191 
+Q 2503 2266 2503 2406 
+Q 2503 2694 2298 2823 
+Q 2094 2953 1713 2953 
+Q 1272 2953 1088 2716 
+Q 984 2584 953 2325 
+L 428 2325 
+Q 444 2944 830 3186 
+Q 1216 3428 1725 3428 
+Q 2316 3428 2684 3203 
+Q 3050 2978 3050 2503 
+L 3050 575 
+Q 3050 488 3086 434 
+Q 3122 381 3238 381 
+Q 3275 381 3322 386 
+Q 3369 391 3422 400 
+L 3422 -16 
+Q 3291 -53 3222 -62 
+Q 3153 -72 3034 -72 
+Q 2744 -72 2613 134 
+Q 2544 244 2516 444 
+Q 2344 219 2022 53 
+Q 1700 -113 1313 -113 
+Q 847 -113 551 170 
+Q 256 453 256 878 
+Q 256 1344 547 1600 
+Q 838 1856 1309 1916 
+L 2206 2028 
+z
+M 1741 3428 
+L 1741 3428 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-51"/>
+       <use xlink:href="#Helvetica-48" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-4a" transform="translate(111.21875 0)"/>
+       <use xlink:href="#Helvetica-44" transform="translate(166.828125 0)"/>
+       <use xlink:href="#Helvetica-57" transform="translate(222.4375 0)"/>
+       <use xlink:href="#Helvetica-4c" transform="translate(250.21875 0)"/>
+       <use xlink:href="#Helvetica-52" transform="translate(272.4375 0)"/>
+       <use xlink:href="#Helvetica-51" transform="translate(328.046875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m8ca0a002df" x="113.777356" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- rule of -->
+      <g transform="translate(101.96634 210.931827) scale(0.085 -0.085)">
+       <defs>
+        <path id="Helvetica-58" d="M 975 3347 
+L 975 1125 
+Q 975 869 1056 706 
+Q 1206 406 1616 406 
+Q 2203 406 2416 931 
+Q 2531 1213 2531 1703 
+L 2531 3347 
+L 3094 3347 
+L 3094 0 
+L 2563 0 
+L 2569 494 
+Q 2459 303 2297 172 
+Q 1975 -91 1516 -91 
+Q 800 -91 541 388 
+Q 400 644 400 1072 
+L 400 3347 
+L 975 3347 
+z
+M 1747 3428 
+L 1747 3428 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-4f" d="M 428 4591 
+L 991 4591 
+L 991 0 
+L 428 0 
+L 428 4591 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-3" transform="scale(0.015625)"/>
+        <path id="Helvetica-49" d="M 553 3856 
+Q 566 4206 675 4369 
+Q 872 4656 1434 4656 
+Q 1488 4656 1544 4653 
+Q 1600 4650 1672 4644 
+L 1672 4131 
+Q 1584 4138 1545 4139 
+Q 1506 4141 1472 4141 
+Q 1216 4141 1166 4008 
+Q 1116 3875 1116 3331 
+L 1672 3331 
+L 1672 2888 
+L 1109 2888 
+L 1109 0 
+L 553 0 
+L 553 2888 
+L 88 2888 
+L 88 3331 
+L 553 3331 
+L 553 3856 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-55"/>
+       <use xlink:href="#Helvetica-58" transform="translate(33.296875 0)"/>
+       <use xlink:href="#Helvetica-4f" transform="translate(88.90625 0)"/>
+       <use xlink:href="#Helvetica-48" transform="translate(111.125 0)"/>
+       <use xlink:href="#Helvetica-3" transform="translate(166.734375 0)"/>
+       <use xlink:href="#Helvetica-52" transform="translate(194.515625 0)"/>
+       <use xlink:href="#Helvetica-49" transform="translate(250.125 0)"/>
+      </g>
+      <!-- three -->
+      <g transform="translate(104.09134 219.004337) scale(0.085 -0.085)">
+       <defs>
+        <path id="Helvetica-4b" d="M 413 4606 
+L 975 4606 
+L 975 2894 
+Q 1175 3147 1334 3250 
+Q 1606 3428 2013 3428 
+Q 2741 3428 3000 2919 
+Q 3141 2641 3141 2147 
+L 3141 0 
+L 2563 0 
+L 2563 2109 
+Q 2563 2478 2469 2650 
+Q 2316 2925 1894 2925 
+Q 1544 2925 1259 2684 
+Q 975 2444 975 1775 
+L 975 0 
+L 413 0 
+L 413 4606 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-57"/>
+       <use xlink:href="#Helvetica-4b" transform="translate(27.78125 0)"/>
+       <use xlink:href="#Helvetica-55" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-48" transform="translate(116.6875 0)"/>
+       <use xlink:href="#Helvetica-48" transform="translate(172.296875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m8ca0a002df" x="163.956163" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- setup / -->
+      <g transform="translate(151.198858 210.931827) scale(0.085 -0.085)">
+       <defs>
+        <path id="Helvetica-56" d="M 747 1050 
+Q 772 769 888 619 
+Q 1100 347 1625 347 
+Q 1938 347 2175 483 
+Q 2413 619 2413 903 
+Q 2413 1119 2222 1231 
+Q 2100 1300 1741 1391 
+L 1294 1503 
+Q 866 1609 663 1741 
+Q 300 1969 300 2372 
+Q 300 2847 642 3140 
+Q 984 3434 1563 3434 
+Q 2319 3434 2653 2991 
+Q 2863 2709 2856 2384 
+L 2325 2384 
+Q 2309 2575 2191 2731 
+Q 1997 2953 1519 2953 
+Q 1200 2953 1036 2831 
+Q 872 2709 872 2509 
+Q 872 2291 1088 2159 
+Q 1213 2081 1456 2022 
+L 1828 1931 
+Q 2434 1784 2641 1647 
+Q 2969 1431 2969 969 
+Q 2969 522 2630 197 
+Q 2291 -128 1597 -128 
+Q 850 -128 539 211 
+Q 228 550 206 1050 
+L 747 1050 
+z
+M 1578 3428 
+L 1578 3428 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-53" d="M 1825 378 
+Q 2219 378 2480 708 
+Q 2741 1038 2741 1694 
+Q 2741 2094 2625 2381 
+Q 2406 2934 1825 2934 
+Q 1241 2934 1025 2350 
+Q 909 2038 909 1556 
+Q 909 1169 1025 897 
+Q 1244 378 1825 378 
+z
+M 369 3331 
+L 916 3331 
+L 916 2888 
+Q 1084 3116 1284 3241 
+Q 1569 3428 1953 3428 
+Q 2522 3428 2919 2992 
+Q 3316 2556 3316 1747 
+Q 3316 653 2744 184 
+Q 2381 -113 1900 -113 
+Q 1522 -113 1266 53 
+Q 1116 147 931 375 
+L 931 -1334 
+L 369 -1334 
+L 369 3331 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-12" d="M 1456 4591 
+L 1931 4591 
+L 475 0 
+L 0 0 
+L 1456 4591 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-56"/>
+       <use xlink:href="#Helvetica-48" transform="translate(50 0)"/>
+       <use xlink:href="#Helvetica-57" transform="translate(105.609375 0)"/>
+       <use xlink:href="#Helvetica-58" transform="translate(133.390625 0)"/>
+       <use xlink:href="#Helvetica-53" transform="translate(189 0)"/>
+       <use xlink:href="#Helvetica-3" transform="translate(244.609375 0)"/>
+       <use xlink:href="#Helvetica-12" transform="translate(272.390625 0)"/>
+      </g>
+      <!-- payoff -->
+      <g transform="translate(152.453936 219.331719) scale(0.085 -0.085)">
+       <defs>
+        <path id="Helvetica-5c" d="M 2503 3347 
+L 3125 3347 
+Q 3006 3025 2597 1878 
+Q 2291 1016 2084 472 
+Q 1597 -809 1397 -1090 
+Q 1197 -1372 709 -1372 
+Q 591 -1372 527 -1362 
+Q 463 -1353 369 -1328 
+L 369 -816 
+Q 516 -856 581 -865 
+Q 647 -875 697 -875 
+Q 853 -875 926 -823 
+Q 1000 -772 1050 -697 
+Q 1066 -672 1162 -440 
+Q 1259 -209 1303 -97 
+L 66 3347 
+L 703 3347 
+L 1600 622 
+L 2503 3347 
+z
+M 1597 3428 
+L 1597 3428 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-53"/>
+       <use xlink:href="#Helvetica-44" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-5c" transform="translate(111.21875 0)"/>
+       <use xlink:href="#Helvetica-52" transform="translate(161.21875 0)"/>
+       <use xlink:href="#Helvetica-49" transform="translate(216.828125 0)"/>
+       <use xlink:href="#Helvetica-49" transform="translate(242.859375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m8ca0a002df" x="214.13497" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- landing -->
+      <g transform="translate(200.429384 210.931827) scale(0.085 -0.085)">
+       <defs>
+        <path id="Helvetica-47" d="M 769 1634 
+Q 769 1097 997 734 
+Q 1225 372 1728 372 
+Q 2119 372 2370 708 
+Q 2622 1044 2622 1672 
+Q 2622 2306 2362 2611 
+Q 2103 2916 1722 2916 
+Q 1297 2916 1033 2591 
+Q 769 2266 769 1634 
+z
+M 1616 3406 
+Q 2000 3406 2259 3244 
+Q 2409 3150 2600 2916 
+L 2600 4606 
+L 3141 4606 
+L 3141 0 
+L 2634 0 
+L 2634 466 
+Q 2438 156 2169 18 
+Q 1900 -119 1553 -119 
+Q 994 -119 584 351 
+Q 175 822 175 1603 
+Q 175 2334 548 2870 
+Q 922 3406 1616 3406 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-4f"/>
+       <use xlink:href="#Helvetica-44" transform="translate(22.21875 0)"/>
+       <use xlink:href="#Helvetica-51" transform="translate(77.828125 0)"/>
+       <use xlink:href="#Helvetica-47" transform="translate(133.4375 0)"/>
+       <use xlink:href="#Helvetica-4c" transform="translate(189.046875 0)"/>
+       <use xlink:href="#Helvetica-51" transform="translate(211.265625 0)"/>
+       <use xlink:href="#Helvetica-4a" transform="translate(266.875 0)"/>
+      </g>
+      <!-- sentence -->
+      <g transform="translate(196.887274 219.440626) scale(0.085 -0.085)">
+       <use xlink:href="#Helvetica-56"/>
+       <use xlink:href="#Helvetica-48" transform="translate(50 0)"/>
+       <use xlink:href="#Helvetica-51" transform="translate(105.609375 0)"/>
+       <use xlink:href="#Helvetica-57" transform="translate(161.21875 0)"/>
+       <use xlink:href="#Helvetica-48" transform="translate(189 0)"/>
+       <use xlink:href="#Helvetica-51" transform="translate(244.609375 0)"/>
+       <use xlink:href="#Helvetica-46" transform="translate(300.21875 0)"/>
+       <use xlink:href="#Helvetica-48" transform="translate(350.21875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m8ca0a002df" x="264.313776" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- contrast / -->
+      <g transform="translate(246.835651 210.931827) scale(0.085 -0.085)">
+       <use xlink:href="#Helvetica-46"/>
+       <use xlink:href="#Helvetica-52" transform="translate(50 0)"/>
+       <use xlink:href="#Helvetica-51" transform="translate(105.609375 0)"/>
+       <use xlink:href="#Helvetica-57" transform="translate(161.21875 0)"/>
+       <use xlink:href="#Helvetica-55" transform="translate(189 0)"/>
+       <use xlink:href="#Helvetica-44" transform="translate(222.296875 0)"/>
+       <use xlink:href="#Helvetica-56" transform="translate(277.90625 0)"/>
+       <use xlink:href="#Helvetica-57" transform="translate(327.90625 0)"/>
+       <use xlink:href="#Helvetica-3" transform="translate(355.6875 0)"/>
+       <use xlink:href="#Helvetica-12" transform="translate(383.46875 0)"/>
+      </g>
+      <!-- anaphora -->
+      <g transform="translate(246.35487 219.004337) scale(0.085 -0.085)">
+       <use xlink:href="#Helvetica-44"/>
+       <use xlink:href="#Helvetica-51" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-44" transform="translate(111.21875 0)"/>
+       <use xlink:href="#Helvetica-53" transform="translate(166.828125 0)"/>
+       <use xlink:href="#Helvetica-4b" transform="translate(222.4375 0)"/>
+       <use xlink:href="#Helvetica-52" transform="translate(278.046875 0)"/>
+       <use xlink:href="#Helvetica-55" transform="translate(333.65625 0)"/>
+       <use xlink:href="#Helvetica-44" transform="translate(366.953125 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_6">
+      <defs>
+       <path id="me15a2e6f0d" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="32.588047" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 0 -->
+      <g transform="translate(20.305156 200.99274) scale(0.095 -0.095)">
+       <defs>
+        <path id="Helvetica-13" d="M 1731 4475 
+Q 2600 4475 2988 3759 
+Q 3288 3206 3288 2244 
+Q 3288 1331 3016 734 
+Q 2622 -122 1728 -122 
+Q 922 -122 528 578 
+Q 200 1163 200 2147 
+Q 200 2909 397 3456 
+Q 766 4475 1731 4475 
+z
+M 1725 391 
+Q 2163 391 2422 778 
+Q 2681 1166 2681 2222 
+Q 2681 2984 2493 3476 
+Q 2306 3969 1766 3969 
+Q 1269 3969 1039 3501 
+Q 809 3034 809 2125 
+Q 809 1441 956 1025 
+Q 1181 391 1725 391 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="32.588047" y="176.615222" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 1 -->
+      <g transform="translate(20.305156 180.177722) scale(0.095 -0.095)">
+       <defs>
+        <path id="Helvetica-14" d="M 613 3169 
+L 613 3600 
+Q 1222 3659 1462 3798 
+Q 1703 3938 1822 4456 
+L 2266 4456 
+L 2266 0 
+L 1666 0 
+L 1666 3169 
+L 613 3169 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="32.588047" y="155.800204" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 2 -->
+      <g transform="translate(20.305156 159.362704) scale(0.095 -0.095)">
+       <defs>
+        <path id="Helvetica-15" d="M 200 0 
+Q 231 578 439 1006 
+Q 647 1434 1250 1784 
+L 1850 2131 
+Q 2253 2366 2416 2531 
+Q 2672 2791 2672 3125 
+Q 2672 3516 2437 3745 
+Q 2203 3975 1813 3975 
+Q 1234 3975 1013 3538 
+Q 894 3303 881 2888 
+L 309 2888 
+Q 319 3472 525 3841 
+Q 891 4491 1816 4491 
+Q 2584 4491 2939 4075 
+Q 3294 3659 3294 3150 
+Q 3294 2613 2916 2231 
+Q 2697 2009 2131 1694 
+L 1703 1456 
+Q 1397 1288 1222 1134 
+Q 909 863 828 531 
+L 3272 531 
+L 3272 0 
+L 200 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="32.588047" y="134.985186" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 3 -->
+      <g transform="translate(20.305156 138.547686) scale(0.095 -0.095)">
+       <defs>
+        <path id="Helvetica-16" d="M 1663 -122 
+Q 869 -122 511 314 
+Q 153 750 153 1375 
+L 741 1375 
+Q 778 941 903 744 
+Q 1122 391 1694 391 
+Q 2138 391 2406 628 
+Q 2675 866 2675 1241 
+Q 2675 1703 2392 1887 
+Q 2109 2072 1606 2072 
+Q 1550 2072 1492 2070 
+Q 1434 2069 1375 2066 
+L 1375 2563 
+Q 1463 2553 1522 2550 
+Q 1581 2547 1650 2547 
+Q 1966 2547 2169 2647 
+Q 2525 2822 2525 3272 
+Q 2525 3606 2287 3787 
+Q 2050 3969 1734 3969 
+Q 1172 3969 956 3594 
+Q 838 3388 822 3006 
+L 266 3006 
+Q 266 3506 466 3856 
+Q 809 4481 1675 4481 
+Q 2359 4481 2734 4176 
+Q 3109 3872 3109 3294 
+Q 3109 2881 2888 2625 
+Q 2750 2466 2531 2375 
+Q 2884 2278 3082 2001 
+Q 3281 1725 3281 1325 
+Q 3281 684 2859 281 
+Q 2438 -122 1663 -122 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="32.588047" y="114.170168" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 4 -->
+      <g transform="translate(20.305156 117.732668) scale(0.095 -0.095)">
+       <defs>
+        <path id="Helvetica-17" d="M 2116 1584 
+L 2116 3613 
+L 681 1584 
+L 2116 1584 
+z
+M 2125 0 
+L 2125 1094 
+L 163 1094 
+L 163 1644 
+L 2213 4488 
+L 2688 4488 
+L 2688 1584 
+L 3347 1584 
+L 3347 1094 
+L 2688 1094 
+L 2688 0 
+L 2125 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="32.588047" y="93.35515" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 5 -->
+      <g transform="translate(20.305156 96.91765) scale(0.095 -0.095)">
+       <defs>
+        <path id="Helvetica-18" d="M 791 1141 
+Q 847 659 1238 475 
+Q 1438 381 1700 381 
+Q 2200 381 2440 700 
+Q 2681 1019 2681 1406 
+Q 2681 1875 2395 2131 
+Q 2109 2388 1709 2388 
+Q 1419 2388 1211 2275 
+Q 1003 2163 856 1963 
+L 369 1991 
+L 709 4400 
+L 3034 4400 
+L 3034 3856 
+L 1131 3856 
+L 941 2613 
+Q 1097 2731 1238 2791 
+Q 1488 2894 1816 2894 
+Q 2431 2894 2859 2497 
+Q 3288 2100 3288 1491 
+Q 3288 856 2895 371 
+Q 2503 -113 1644 -113 
+Q 1097 -113 676 195 
+Q 256 503 206 1141 
+L 791 1141 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-18"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="32.588047" y="72.540132" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 6 -->
+      <g transform="translate(20.305156 76.102632) scale(0.095 -0.095)">
+       <defs>
+        <path id="Helvetica-19" d="M 1872 4494 
+Q 2622 4494 2917 4105 
+Q 3213 3716 3213 3303 
+L 2656 3303 
+Q 2606 3569 2497 3719 
+Q 2294 4000 1881 4000 
+Q 1409 4000 1131 3564 
+Q 853 3128 822 2316 
+Q 1016 2600 1309 2741 
+Q 1578 2866 1909 2866 
+Q 2472 2866 2890 2506 
+Q 3309 2147 3309 1434 
+Q 3309 825 2912 354 
+Q 2516 -116 1781 -116 
+Q 1153 -116 697 361 
+Q 241 838 241 1966 
+Q 241 2800 444 3381 
+Q 834 4494 1872 4494 
+z
+M 1831 384 
+Q 2275 384 2495 682 
+Q 2716 981 2716 1388 
+Q 2716 1731 2519 2042 
+Q 2322 2353 1803 2353 
+Q 1441 2353 1167 2112 
+Q 894 1872 894 1388 
+Q 894 963 1142 673 
+Q 1391 384 1831 384 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-19"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="32.588047" y="51.725114" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 7 -->
+      <g transform="translate(20.305156 55.287614) scale(0.095 -0.095)">
+       <defs>
+        <path id="Helvetica-1a" d="M 3347 4400 
+L 3347 3909 
+Q 3131 3700 2773 3181 
+Q 2416 2663 2141 2063 
+Q 1869 1478 1728 997 
+Q 1638 688 1494 0 
+L 872 0 
+Q 1084 1281 1809 2550 
+Q 2238 3294 2709 3834 
+L 234 3834 
+L 234 4400 
+L 3347 4400 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-1a"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="32.588047" y="30.910096" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 8 -->
+      <g transform="translate(20.305156 34.472596) scale(0.095 -0.095)">
+       <defs>
+        <path id="Helvetica-1b" d="M 1741 2600 
+Q 2113 2600 2322 2808 
+Q 2531 3016 2531 3303 
+Q 2531 3553 2331 3762 
+Q 2131 3972 1722 3972 
+Q 1316 3972 1134 3762 
+Q 953 3553 953 3272 
+Q 953 2956 1187 2778 
+Q 1422 2600 1741 2600 
+z
+M 1775 384 
+Q 2166 384 2423 595 
+Q 2681 806 2681 1225 
+Q 2681 1659 2415 1884 
+Q 2150 2109 1734 2109 
+Q 1331 2109 1076 1879 
+Q 822 1650 822 1244 
+Q 822 894 1055 639 
+Q 1288 384 1775 384 
+z
+M 975 2384 
+Q 741 2484 609 2619 
+Q 363 2869 363 3269 
+Q 363 3769 725 4128 
+Q 1088 4488 1753 4488 
+Q 2397 4488 2762 4148 
+Q 3128 3809 3128 3356 
+Q 3128 2938 2916 2678 
+Q 2797 2531 2547 2391 
+Q 2825 2263 2984 2097 
+Q 3281 1784 3281 1284 
+Q 3281 694 2884 283 
+Q 2488 -128 1763 -128 
+Q 1109 -128 657 226 
+Q 206 581 206 1256 
+Q 206 1653 400 1942 
+Q 594 2231 975 2384 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-1b"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_15">
+     <!-- devices per 100 sentences -->
+     <g transform="translate(14.325 165.230459) rotate(-90) scale(0.095 -0.095)">
+      <use xlink:href="#Helvetica-47"/>
+      <use xlink:href="#Helvetica-48" transform="translate(55.609375 0)"/>
+      <use xlink:href="#Helvetica-59" transform="translate(111.21875 0)"/>
+      <use xlink:href="#Helvetica-4c" transform="translate(161.21875 0)"/>
+      <use xlink:href="#Helvetica-46" transform="translate(183.4375 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(233.4375 0)"/>
+      <use xlink:href="#Helvetica-56" transform="translate(289.046875 0)"/>
+      <use xlink:href="#Helvetica-3" transform="translate(339.046875 0)"/>
+      <use xlink:href="#Helvetica-53" transform="translate(366.828125 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(422.4375 0)"/>
+      <use xlink:href="#Helvetica-55" transform="translate(478.046875 0)"/>
+      <use xlink:href="#Helvetica-3" transform="translate(511.34375 0)"/>
+      <use xlink:href="#Helvetica-14" transform="translate(539.125 0)"/>
+      <use xlink:href="#Helvetica-13" transform="translate(594.734375 0)"/>
+      <use xlink:href="#Helvetica-13" transform="translate(650.34375 0)"/>
+      <use xlink:href="#Helvetica-3" transform="translate(705.953125 0)"/>
+      <use xlink:href="#Helvetica-56" transform="translate(733.734375 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(783.734375 0)"/>
+      <use xlink:href="#Helvetica-51" transform="translate(839.34375 0)"/>
+      <use xlink:href="#Helvetica-57" transform="translate(894.953125 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(922.734375 0)"/>
+      <use xlink:href="#Helvetica-51" transform="translate(978.34375 0)"/>
+      <use xlink:href="#Helvetica-46" transform="translate(1033.953125 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(1083.953125 0)"/>
+      <use xlink:href="#Helvetica-56" transform="translate(1139.5625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_13">
+    <path d="M 32.588047 197.43024 
+L 32.588047 20.02224 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 32.588047 197.43024 
+L 295.324279 197.43024 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_16">
+    <!-- 6.2 -->
+    <g style="fill: #4b5563" transform="translate(48.504576 66.215569) scale(0.08 -0.08)">
+     <defs>
+      <path id="Helvetica-11" d="M 547 681 
+L 1200 681 
+L 1200 0 
+L 547 0 
+L 547 681 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-19"/>
+     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+     <use xlink:href="#Helvetica-15" transform="translate(83.390625 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 6.9 -->
+    <g style="fill: #4b5563" transform="translate(98.683383 50.204016) scale(0.08 -0.08)">
+     <defs>
+      <path id="Helvetica-1c" d="M 850 1081 
+Q 875 616 1209 438 
+Q 1381 344 1597 344 
+Q 2000 344 2284 680 
+Q 2569 1016 2688 2044 
+Q 2500 1747 2223 1626 
+Q 1947 1506 1628 1506 
+Q 981 1506 604 1909 
+Q 228 2313 228 2947 
+Q 228 3556 600 4018 
+Q 972 4481 1697 4481 
+Q 2675 4481 3047 3600 
+Q 3253 3116 3253 2388 
+Q 3253 1566 3006 931 
+Q 2597 -125 1619 -125 
+Q 963 -125 622 219 
+Q 281 563 281 1081 
+L 850 1081 
+z
+M 1703 2000 
+Q 2038 2000 2314 2220 
+Q 2591 2441 2591 2991 
+Q 2591 3484 2342 3726 
+Q 2094 3969 1709 3969 
+Q 1297 3969 1055 3692 
+Q 813 3416 813 2953 
+Q 813 2516 1025 2258 
+Q 1238 2000 1703 2000 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-19"/>
+     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+     <use xlink:href="#Helvetica-1c" transform="translate(83.390625 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 6.2 -->
+    <g style="fill: #4b5563" transform="translate(148.86219 66.215569) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-19"/>
+     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+     <use xlink:href="#Helvetica-15" transform="translate(83.390625 0)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 4.6 -->
+    <g style="fill: #4b5563" transform="translate(199.040996 98.238673) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-17"/>
+     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+     <use xlink:href="#Helvetica-19" transform="translate(83.390625 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 4.6 -->
+    <g style="fill: #4b5563" transform="translate(249.219803 98.238673) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-17"/>
+     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+     <use xlink:href="#Helvetica-19" transform="translate(83.390625 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 0 -->
+    <g style="fill: #2563eb" transform="translate(70.908148 194.307987) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-13"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 0 -->
+    <g style="fill: #2563eb" transform="translate(121.086954 194.307987) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-13"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 0 -->
+    <g style="fill: #2563eb" transform="translate(171.265761 194.307987) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-13"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 0 -->
+    <g style="fill: #2563eb" transform="translate(221.444568 194.307987) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-13"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 2.6 -->
+    <g style="fill: #2563eb" transform="translate(268.287749 140.936146) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-15"/>
+     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+     <use xlink:href="#Helvetica-19" transform="translate(83.390625 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- (a) -->
+    <g transform="translate(35.215409 14.7) scale(0.1 -0.1)">
+     <defs>
+      <path id="Helvetica-Bold-b" d="M 1394 -1291 
+L 1172 -988 
+Q 956 -713 713 -169 
+Q 278 803 278 1744 
+Q 278 2600 644 3444 
+Q 891 4019 1366 4681 
+L 2038 4681 
+L 1847 4331 
+Q 1453 3609 1300 2819 
+Q 1200 2300 1200 1688 
+Q 1200 731 1478 -72 
+Q 1641 -547 2053 -1291 
+L 1394 -1291 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-44" d="M 544 3038 
+Q 897 3488 1756 3488 
+Q 2316 3488 2750 3266 
+Q 3184 3044 3184 2428 
+L 3184 866 
+Q 3184 703 3191 472 
+Q 3200 297 3244 234 
+Q 3288 172 3375 131 
+L 3375 0 
+L 2406 0 
+Q 2366 103 2350 193 
+Q 2334 284 2325 400 
+Q 2141 200 1900 59 
+Q 1613 -106 1250 -106 
+Q 788 -106 486 158 
+Q 184 422 184 906 
+Q 184 1534 669 1816 
+Q 934 1969 1450 2034 
+L 1753 2072 
+Q 2000 2103 2106 2150 
+Q 2297 2231 2297 2403 
+Q 2297 2613 2151 2692 
+Q 2006 2772 1725 2772 
+Q 1409 2772 1278 2616 
+Q 1184 2500 1153 2303 
+L 294 2303 
+Q 322 2750 544 3038 
+z
+M 1206 644 
+Q 1331 541 1513 541 
+Q 1800 541 2042 709 
+Q 2284 878 2294 1325 
+L 2294 1656 
+Q 2209 1603 2123 1570 
+Q 2038 1538 1888 1509 
+L 1688 1472 
+Q 1406 1422 1284 1350 
+Q 1078 1228 1078 972 
+Q 1078 744 1206 644 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-c" d="M 947 -988 
+L 725 -1291 
+L 66 -1291 
+Q 478 -547 641 -72 
+Q 919 731 919 1688 
+Q 919 2300 819 2819 
+Q 666 3609 272 4331 
+L 81 4681 
+L 753 4681 
+Q 1228 4019 1475 3444 
+Q 1841 2600 1841 1744 
+Q 1841 803 1406 -169 
+Q 1163 -713 947 -988 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-Bold-b"/>
+     <use xlink:href="#Helvetica-Bold-44" transform="translate(33.296875 0)"/>
+     <use xlink:href="#Helvetica-Bold-c" transform="translate(88.90625 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_15">
+     <path d="M 140.106779 33.22224 
+L 156.106779 33.22224 
+L 156.106779 27.62224 
+L 140.106779 27.62224 
+z
+" style="fill: #4b5563"/>
+    </g>
+    <g id="text_27">
+     <!-- AI-assisted post (n=130 sentences) -->
+     <g transform="translate(162.506779 33.22224) scale(0.08 -0.08)">
+      <defs>
+       <path id="Helvetica-24" d="M 2844 1881 
+L 2147 3909 
+L 1406 1881 
+L 2844 1881 
+z
+M 1822 4591 
+L 2525 4591 
+L 4191 0 
+L 3509 0 
+L 3044 1375 
+L 1228 1375 
+L 731 0 
+L 94 0 
+L 1822 4591 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-2c" d="M 628 4591 
+L 1256 4591 
+L 1256 0 
+L 628 0 
+L 628 4591 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-10" d="M 266 2072 
+L 1834 2072 
+L 1834 1494 
+L 266 1494 
+L 266 2072 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-b" d="M 1894 4666 
+Q 1403 3713 1256 3263 
+Q 1034 2578 1034 1681 
+Q 1034 775 1288 25 
+Q 1444 -438 1903 -1306 
+L 1525 -1306 
+Q 1069 -594 959 -397 
+Q 850 -200 722 138 
+Q 547 600 478 1125 
+Q 444 1397 444 1644 
+Q 444 2569 734 3291 
+Q 919 3750 1503 4666 
+L 1894 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-20" d="M 3547 2569 
+L 3547 2044 
+L 288 2044 
+L 288 2569 
+L 3547 2569 
+z
+M 3547 1228 
+L 3547 694 
+L 288 694 
+L 288 1228 
+L 3547 1228 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-c" d="M 222 -1306 
+Q 719 -338 863 106 
+Q 1081 778 1081 1681 
+Q 1081 2584 828 3334 
+Q 672 3797 213 4666 
+L 591 4666 
+Q 1072 3897 1173 3717 
+Q 1275 3538 1394 3222 
+Q 1544 2831 1608 2450 
+Q 1672 2069 1672 1716 
+Q 1672 791 1378 66 
+Q 1194 -400 613 -1306 
+L 222 -1306 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#Helvetica-24"/>
+      <use xlink:href="#Helvetica-2c" transform="translate(66.703125 0)"/>
+      <use xlink:href="#Helvetica-10" transform="translate(94.484375 0)"/>
+      <use xlink:href="#Helvetica-44" transform="translate(127.78125 0)"/>
+      <use xlink:href="#Helvetica-56" transform="translate(183.390625 0)"/>
+      <use xlink:href="#Helvetica-56" transform="translate(233.390625 0)"/>
+      <use xlink:href="#Helvetica-4c" transform="translate(283.390625 0)"/>
+      <use xlink:href="#Helvetica-56" transform="translate(305.609375 0)"/>
+      <use xlink:href="#Helvetica-57" transform="translate(355.609375 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(383.390625 0)"/>
+      <use xlink:href="#Helvetica-47" transform="translate(439 0)"/>
+      <use xlink:href="#Helvetica-3" transform="translate(494.609375 0)"/>
+      <use xlink:href="#Helvetica-53" transform="translate(522.390625 0)"/>
+      <use xlink:href="#Helvetica-52" transform="translate(578 0)"/>
+      <use xlink:href="#Helvetica-56" transform="translate(633.609375 0)"/>
+      <use xlink:href="#Helvetica-57" transform="translate(683.609375 0)"/>
+      <use xlink:href="#Helvetica-3" transform="translate(711.390625 0)"/>
+      <use xlink:href="#Helvetica-b" transform="translate(739.171875 0)"/>
+      <use xlink:href="#Helvetica-51" transform="translate(772.46875 0)"/>
+      <use xlink:href="#Helvetica-20" transform="translate(828.078125 0)"/>
+      <use xlink:href="#Helvetica-14" transform="translate(886.484375 0)"/>
+      <use xlink:href="#Helvetica-16" transform="translate(942.09375 0)"/>
+      <use xlink:href="#Helvetica-13" transform="translate(997.703125 0)"/>
+      <use xlink:href="#Helvetica-3" transform="translate(1053.3125 0)"/>
+      <use xlink:href="#Helvetica-56" transform="translate(1081.09375 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(1131.09375 0)"/>
+      <use xlink:href="#Helvetica-51" transform="translate(1186.703125 0)"/>
+      <use xlink:href="#Helvetica-57" transform="translate(1242.3125 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(1270.09375 0)"/>
+      <use xlink:href="#Helvetica-51" transform="translate(1325.703125 0)"/>
+      <use xlink:href="#Helvetica-46" transform="translate(1381.3125 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(1431.3125 0)"/>
+      <use xlink:href="#Helvetica-56" transform="translate(1486.921875 0)"/>
+      <use xlink:href="#Helvetica-c" transform="translate(1536.921875 0)"/>
+     </g>
+    </g>
+    <g id="patch_16">
+     <path d="M 140.106779 44.88974 
+L 156.106779 44.88974 
+L 156.106779 39.28974 
+L 140.106779 39.28974 
+z
+" style="fill: #2563eb"/>
+    </g>
+    <g id="text_28">
+     <!-- this post (n=39) -->
+     <g transform="translate(162.506779 44.88974) scale(0.08 -0.08)">
+      <use xlink:href="#Helvetica-57"/>
+      <use xlink:href="#Helvetica-4b" transform="translate(27.78125 0)"/>
+      <use xlink:href="#Helvetica-4c" transform="translate(83.390625 0)"/>
+      <use xlink:href="#Helvetica-56" transform="translate(105.609375 0)"/>
+      <use xlink:href="#Helvetica-3" transform="translate(155.609375 0)"/>
+      <use xlink:href="#Helvetica-53" transform="translate(183.390625 0)"/>
+      <use xlink:href="#Helvetica-52" transform="translate(239 0)"/>
+      <use xlink:href="#Helvetica-56" transform="translate(294.609375 0)"/>
+      <use xlink:href="#Helvetica-57" transform="translate(344.609375 0)"/>
+      <use xlink:href="#Helvetica-3" transform="translate(372.390625 0)"/>
+      <use xlink:href="#Helvetica-b" transform="translate(400.171875 0)"/>
+      <use xlink:href="#Helvetica-51" transform="translate(433.46875 0)"/>
+      <use xlink:href="#Helvetica-20" transform="translate(489.078125 0)"/>
+      <use xlink:href="#Helvetica-16" transform="translate(547.484375 0)"/>
+      <use xlink:href="#Helvetica-1c" transform="translate(603.09375 0)"/>
+      <use xlink:href="#Helvetica-c" transform="translate(658.703125 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_17">
+    <path d="M 357.917322 197.43024 
+L 512.468047 197.43024 
+L 512.468047 20.02224 
+L 357.917322 20.02224 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 364.942355 197.43024 
+L 364.942355 178.656907 
+L 374.309066 178.656907 
+L 374.309066 84.79024 
+L 383.675776 84.79024 
+L 383.675776 28.47024 
+L 393.042487 28.47024 
+L 393.042487 84.79024 
+L 402.409198 84.79024 
+L 402.409198 66.016907 
+L 411.775908 66.016907 
+L 411.775908 91.048018 
+L 421.142619 91.048018 
+L 421.142619 141.11024 
+L 430.509329 141.11024 
+L 430.509329 147.368018 
+L 439.87604 147.368018 
+L 439.87604 178.656907 
+L 449.24275 178.656907 
+L 449.24275 184.914684 
+L 458.609461 184.914684 
+L 458.609461 184.914684 
+L 467.976172 184.914684 
+L 467.976172 197.43024 
+L 477.342882 197.43024 
+L 477.342882 191.172462 
+L 486.709593 191.172462 
+L 486.709593 197.43024 
+L 496.076303 197.43024 
+L 496.076303 191.172462 
+L 505.443014 191.172462 
+L 505.443014 197.43024 
+L 496.076303 197.43024 
+L 496.076303 197.43024 
+L 486.709593 197.43024 
+L 486.709593 197.43024 
+L 477.342882 197.43024 
+L 477.342882 197.43024 
+L 467.976172 197.43024 
+L 467.976172 197.43024 
+L 458.609461 197.43024 
+L 458.609461 197.43024 
+L 449.24275 197.43024 
+L 449.24275 197.43024 
+L 439.87604 197.43024 
+L 439.87604 197.43024 
+L 430.509329 197.43024 
+L 430.509329 197.43024 
+L 421.142619 197.43024 
+L 421.142619 197.43024 
+L 411.775908 197.43024 
+L 411.775908 197.43024 
+L 402.409198 197.43024 
+L 402.409198 197.43024 
+L 393.042487 197.43024 
+L 393.042487 197.43024 
+L 383.675776 197.43024 
+L 383.675776 197.43024 
+L 374.309066 197.43024 
+L 374.309066 197.43024 
+z
+" clip-path="url(#p09216fdf78)" style="fill: #9ca3af; opacity: 0.85"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 364.942355 197.43024 
+L 364.942355 134.852462 
+L 374.309066 134.852462 
+L 374.309066 72.274684 
+L 383.675776 72.274684 
+L 383.675776 93.133944 
+L 393.042487 93.133944 
+L 393.042487 30.556166 
+L 402.409198 30.556166 
+L 402.409198 155.711721 
+L 411.775908 155.711721 
+L 411.775908 113.993203 
+L 421.142619 113.993203 
+L 421.142619 155.711721 
+L 430.509329 155.711721 
+L 430.509329 113.993203 
+L 439.87604 113.993203 
+L 439.87604 134.852462 
+L 449.24275 134.852462 
+L 449.24275 197.43024 
+L 458.609461 197.43024 
+L 458.609461 176.570981 
+L 467.976172 176.570981 
+L 467.976172 197.43024 
+L 477.342882 197.43024 
+L 477.342882 176.570981 
+L 486.709593 176.570981 
+L 486.709593 197.43024 
+L 496.076303 197.43024 
+L 496.076303 197.43024 
+L 505.443014 197.43024 
+L 505.443014 197.43024 
+L 496.076303 197.43024 
+L 496.076303 197.43024 
+L 486.709593 197.43024 
+L 486.709593 197.43024 
+L 477.342882 197.43024 
+L 477.342882 197.43024 
+L 467.976172 197.43024 
+L 467.976172 197.43024 
+L 458.609461 197.43024 
+L 458.609461 197.43024 
+L 449.24275 197.43024 
+L 449.24275 197.43024 
+L 439.87604 197.43024 
+L 439.87604 197.43024 
+L 430.509329 197.43024 
+L 430.509329 197.43024 
+L 421.142619 197.43024 
+L 421.142619 197.43024 
+L 411.775908 197.43024 
+L 411.775908 197.43024 
+L 402.409198 197.43024 
+L 402.409198 197.43024 
+L 393.042487 197.43024 
+L 393.042487 197.43024 
+L 383.675776 197.43024 
+L 383.675776 197.43024 
+L 374.309066 197.43024 
+L 374.309066 197.43024 
+z
+" clip-path="url(#p09216fdf78)" style="fill: #2563eb; opacity: 0.4; stroke: #2563eb; stroke-linejoin: miter"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_6">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m8ca0a002df" x="364.942355" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 0 -->
+      <g transform="translate(362.30091 211.55524) scale(0.095 -0.095)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m8ca0a002df" x="396.164724" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <!-- 10 -->
+      <g transform="translate(390.881833 211.55524) scale(0.095 -0.095)">
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m8ca0a002df" x="427.387092" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 20 -->
+      <g transform="translate(422.104202 211.55524) scale(0.095 -0.095)">
+       <use xlink:href="#Helvetica-15"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m8ca0a002df" x="458.609461" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_32">
+      <!-- 30 -->
+      <g transform="translate(453.32657 211.55524) scale(0.095 -0.095)">
+       <use xlink:href="#Helvetica-16"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m8ca0a002df" x="489.83183" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_33">
+      <!-- 40 -->
+      <g transform="translate(484.548939 211.55524) scale(0.095 -0.095)">
+       <use xlink:href="#Helvetica-17"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_34">
+     <!-- words per sentence -->
+     <g transform="translate(393.742255 224.294498) scale(0.095 -0.095)">
+      <defs>
+       <path id="Helvetica-5a" d="M 672 3347 
+L 1316 709 
+L 1969 3347 
+L 2600 3347 
+L 3256 725 
+L 3941 3347 
+L 4503 3347 
+L 3531 0 
+L 2947 0 
+L 2266 2591 
+L 1606 0 
+L 1022 0 
+L 56 3347 
+L 672 3347 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#Helvetica-5a"/>
+      <use xlink:href="#Helvetica-52" transform="translate(72.21875 0)"/>
+      <use xlink:href="#Helvetica-55" transform="translate(127.828125 0)"/>
+      <use xlink:href="#Helvetica-47" transform="translate(161.125 0)"/>
+      <use xlink:href="#Helvetica-56" transform="translate(216.734375 0)"/>
+      <use xlink:href="#Helvetica-3" transform="translate(266.734375 0)"/>
+      <use xlink:href="#Helvetica-53" transform="translate(294.515625 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(350.125 0)"/>
+      <use xlink:href="#Helvetica-55" transform="translate(405.734375 0)"/>
+      <use xlink:href="#Helvetica-3" transform="translate(439.03125 0)"/>
+      <use xlink:href="#Helvetica-56" transform="translate(466.8125 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(516.8125 0)"/>
+      <use xlink:href="#Helvetica-51" transform="translate(572.421875 0)"/>
+      <use xlink:href="#Helvetica-57" transform="translate(628.03125 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(655.8125 0)"/>
+      <use xlink:href="#Helvetica-51" transform="translate(711.421875 0)"/>
+      <use xlink:href="#Helvetica-46" transform="translate(767.03125 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(817.03125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_10">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="357.917322" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_35">
+      <!-- 0.00 -->
+      <g transform="translate(332.429432 200.99274) scale(0.095 -0.095)">
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="357.917322" y="173.024907" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_36">
+      <!-- 0.01 -->
+      <g transform="translate(332.429432 176.587407) scale(0.095 -0.095)">
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-14" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="357.917322" y="148.619573" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_37">
+      <!-- 0.02 -->
+      <g transform="translate(332.429432 152.182073) scale(0.095 -0.095)">
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-15" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="357.917322" y="124.21424" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_38">
+      <!-- 0.03 -->
+      <g transform="translate(332.429432 127.77674) scale(0.095 -0.095)">
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-16" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="357.917322" y="99.808907" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_39">
+      <!-- 0.04 -->
+      <g transform="translate(332.429432 103.371407) scale(0.095 -0.095)">
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-17" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="357.917322" y="75.403573" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_40">
+      <!-- 0.05 -->
+      <g transform="translate(332.429432 78.966073) scale(0.095 -0.095)">
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="357.917322" y="50.99824" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_41">
+      <!-- 0.06 -->
+      <g transform="translate(332.429432 54.56074) scale(0.095 -0.095)">
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-19" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#me15a2e6f0d" x="357.917322" y="26.592907" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_42">
+      <!-- 0.07 -->
+      <g transform="translate(332.429432 30.155407) scale(0.095 -0.095)">
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-1a" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_43">
+     <!-- density -->
+     <g transform="translate(326.392869 123.775576) rotate(-90) scale(0.095 -0.095)">
+      <use xlink:href="#Helvetica-47"/>
+      <use xlink:href="#Helvetica-48" transform="translate(55.609375 0)"/>
+      <use xlink:href="#Helvetica-51" transform="translate(111.21875 0)"/>
+      <use xlink:href="#Helvetica-56" transform="translate(166.828125 0)"/>
+      <use xlink:href="#Helvetica-4c" transform="translate(216.828125 0)"/>
+      <use xlink:href="#Helvetica-57" transform="translate(239.046875 0)"/>
+      <use xlink:href="#Helvetica-5c" transform="translate(266.828125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_20">
+    <path d="M 357.917322 197.43024 
+L 357.917322 20.02224 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 357.917322 197.43024 
+L 512.468047 197.43024 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_44">
+    <!-- σ = 7.3 -->
+    <g style="fill: #4b5563" transform="translate(478.021799 33.86856) scale(0.09 -0.09)">
+     <defs>
+      <path id="Helvetica-46b" d="M 3878 2866 
+L 3150 2866 
+Q 3559 2444 3566 1728 
+Q 3566 934 3163 447 
+Q 2753 -50 1953 -63 
+Q 1147 -50 750 459 
+Q 347 959 347 1728 
+Q 353 2469 788 2925 
+Q 1216 3384 1953 3391 
+Q 2266 3384 2444 3328 
+L 3878 3328 
+L 3878 2866 
+z
+M 2950 1656 
+Q 2950 2125 2731 2516 
+Q 2503 2919 1953 2931 
+Q 1409 2919 1184 2534 
+Q 953 2150 959 1656 
+Q 959 1119 1228 769 
+Q 1484 403 1953 397 
+Q 2469 403 2713 788 
+Q 2950 1159 2950 1656 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-46b"/>
+     <use xlink:href="#Helvetica-3" transform="translate(61.078125 0)"/>
+     <use xlink:href="#Helvetica-20" transform="translate(88.859375 0)"/>
+     <use xlink:href="#Helvetica-3" transform="translate(147.265625 0)"/>
+     <use xlink:href="#Helvetica-1a" transform="translate(175.046875 0)"/>
+     <use xlink:href="#Helvetica-11" transform="translate(230.65625 0)"/>
+     <use xlink:href="#Helvetica-16" transform="translate(258.4375 0)"/>
+    </g>
+   </g>
+   <g id="text_45">
+    <!-- σ = 8.8 -->
+    <g style="fill: #2563eb" transform="translate(478.021799 51.60936) scale(0.09 -0.09)">
+     <use xlink:href="#Helvetica-46b"/>
+     <use xlink:href="#Helvetica-3" transform="translate(61.078125 0)"/>
+     <use xlink:href="#Helvetica-20" transform="translate(88.859375 0)"/>
+     <use xlink:href="#Helvetica-3" transform="translate(147.265625 0)"/>
+     <use xlink:href="#Helvetica-1b" transform="translate(175.046875 0)"/>
+     <use xlink:href="#Helvetica-11" transform="translate(230.65625 0)"/>
+     <use xlink:href="#Helvetica-1b" transform="translate(258.4375 0)"/>
+    </g>
+   </g>
+   <g id="text_46">
+    <!-- (b) -->
+    <g transform="translate(362.553844 14.7) scale(0.1 -0.1)">
+     <defs>
+      <path id="Helvetica-Bold-45" d="M 2266 -91 
+Q 1844 -91 1588 78 
+Q 1434 178 1256 428 
+L 1256 0 
+L 384 0 
+L 384 4600 
+L 1272 4600 
+L 1272 2963 
+Q 1441 3200 1644 3325 
+Q 1884 3481 2256 3481 
+Q 2928 3481 3308 2997 
+Q 3688 2513 3688 1747 
+Q 3688 953 3313 431 
+Q 2938 -91 2266 -91 
+z
+M 2753 1653 
+Q 2753 2016 2659 2253 
+Q 2481 2703 2003 2703 
+Q 1519 2703 1338 2263 
+Q 1244 2028 1244 1656 
+Q 1244 1219 1437 931 
+Q 1631 644 2028 644 
+Q 2372 644 2562 922 
+Q 2753 1200 2753 1653 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-Bold-b"/>
+     <use xlink:href="#Helvetica-Bold-45" transform="translate(33.296875 0)"/>
+     <use xlink:href="#Helvetica-Bold-c" transform="translate(94.375 0)"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p34fe4b285d">
+   <rect x="32.588047" y="20.02224" width="262.736232" height="177.408"/>
+  </clipPath>
+  <clipPath id="p09216fdf78">
+   <rect x="357.917322" y="20.02224" width="154.550725" height="177.408"/>
+  </clipPath>
+ </defs>
 </svg>

--- a/culture/assets/ai-writing-tells.svg
+++ b/culture/assets/ai-writing-tells.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="519.668047pt" height="233.474654pt" viewBox="0 0 519.668047 233.474654" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="634.366948pt" height="249.807914pt" viewBox="0 0 634.366948 249.807914" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-13T06:27:02.616660</dc:date>
+    <dc:date>2026-08-13T06:33:43.116073</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,725 +21,133 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 233.474654 
-L 519.668047 233.474654 
-L 519.668047 0 
+   <path d="M 0 249.807914 
+L 634.366948 249.807914 
+L 634.366948 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 32.588047 197.43024 
-L 295.324279 197.43024 
-L 295.324279 20.02224 
-L 32.588047 20.02224 
+    <path d="M 240.094948 213.7635 
+L 466.522534 213.7635 
+L 466.522534 25.2675 
+L 240.094948 25.2675 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="patch_3">
-    <path d="M 44.530603 197.43024 
-L 63.598549 197.43024 
-L 63.598549 69.337821 
-L 44.530603 69.337821 
+    <path d="M 240.094948 50.987515 
+L 407.50906 50.987515 
+L 407.50906 39.712988 
+L 240.094948 39.712988 
 z
-" clip-path="url(#p34fe4b285d)" style="fill: #4b5563"/>
+" clip-path="url(#pcdef171509)" style="fill: #4b5563"/>
    </g>
    <g id="patch_4">
-    <path d="M 94.70941 197.43024 
-L 113.777356 197.43024 
-L 113.777356 53.326269 
-L 94.70941 53.326269 
+    <path d="M 240.094948 63.671358 
+L 240.094948 63.671358 
+L 240.094948 52.396831 
+L 240.094948 52.396831 
 z
-" clip-path="url(#p34fe4b285d)" style="fill: #4b5563"/>
+" clip-path="url(#pcdef171509)" style="fill: #2563eb"/>
    </g>
    <g id="patch_5">
-    <path d="M 144.888216 197.43024 
-L 163.956163 197.43024 
-L 163.956163 69.337821 
-L 144.888216 69.337821 
+    <path d="M 240.094948 86.220412 
+L 428.435824 86.220412 
+L 428.435824 74.945885 
+L 240.094948 74.945885 
 z
-" clip-path="url(#p34fe4b285d)" style="fill: #4b5563"/>
+" clip-path="url(#pcdef171509)" style="fill: #4b5563"/>
    </g>
    <g id="patch_6">
-    <path d="M 195.067023 197.43024 
-L 214.13497 197.43024 
-L 214.13497 101.360926 
-L 195.067023 101.360926 
+    <path d="M 240.094948 98.904255 
+L 240.094948 98.904255 
+L 240.094948 87.629728 
+L 240.094948 87.629728 
 z
-" clip-path="url(#p34fe4b285d)" style="fill: #4b5563"/>
+" clip-path="url(#pcdef171509)" style="fill: #2563eb"/>
    </g>
    <g id="patch_7">
-    <path d="M 245.24583 197.43024 
-L 264.313776 197.43024 
-L 264.313776 101.360926 
-L 245.24583 101.360926 
+    <path d="M 240.094948 121.453309 
+L 407.50906 121.453309 
+L 407.50906 110.178782 
+L 240.094948 110.178782 
 z
-" clip-path="url(#p34fe4b285d)" style="fill: #4b5563"/>
+" clip-path="url(#pcdef171509)" style="fill: #4b5563"/>
    </g>
    <g id="patch_8">
-    <path d="M 63.598549 197.43024 
-L 82.666496 197.43024 
-L 82.666496 197.43024 
-L 63.598549 197.43024 
+    <path d="M 240.094948 134.137152 
+L 240.094948 134.137152 
+L 240.094948 122.862625 
+L 240.094948 122.862625 
 z
-" clip-path="url(#p34fe4b285d)" style="fill: #2563eb"/>
+" clip-path="url(#pcdef171509)" style="fill: #2563eb"/>
    </g>
    <g id="patch_9">
-    <path d="M 113.777356 197.43024 
-L 132.845303 197.43024 
-L 132.845303 197.43024 
-L 113.777356 197.43024 
+    <path d="M 240.094948 156.686207 
+L 365.655532 156.686207 
+L 365.655532 145.411679 
+L 240.094948 145.411679 
 z
-" clip-path="url(#p34fe4b285d)" style="fill: #2563eb"/>
+" clip-path="url(#pcdef171509)" style="fill: #4b5563"/>
    </g>
    <g id="patch_10">
-    <path d="M 163.956163 197.43024 
-L 183.024109 197.43024 
-L 183.024109 197.43024 
-L 163.956163 197.43024 
+    <path d="M 240.094948 169.37005 
+L 240.094948 169.37005 
+L 240.094948 158.095522 
+L 240.094948 158.095522 
 z
-" clip-path="url(#p34fe4b285d)" style="fill: #2563eb"/>
+" clip-path="url(#pcdef171509)" style="fill: #2563eb"/>
    </g>
    <g id="patch_11">
-    <path d="M 214.13497 197.43024 
-L 233.202916 197.43024 
-L 233.202916 197.43024 
-L 214.13497 197.43024 
+    <path d="M 240.094948 191.919104 
+L 365.655532 191.919104 
+L 365.655532 180.644577 
+L 240.094948 180.644577 
 z
-" clip-path="url(#p34fe4b285d)" style="fill: #2563eb"/>
+" clip-path="url(#pcdef171509)" style="fill: #4b5563"/>
    </g>
    <g id="patch_12">
-    <path d="M 264.313776 197.43024 
-L 283.381723 197.43024 
-L 283.381723 144.058399 
-L 264.313776 144.058399 
+    <path d="M 240.094948 204.602947 
+L 303.361909 204.602947 
+L 303.361909 193.32842 
+L 240.094948 193.32842 
 z
-" clip-path="url(#p34fe4b285d)" style="fill: #2563eb"/>
+" clip-path="url(#pcdef171509)" style="fill: #2563eb"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 229.213031 192.623762 
+L 250.976866 192.623762 
+L 250.976866 192.623762 
+L 229.213031 192.623762 
+z
+" clip-path="url(#pcdef171509)" style="fill: #4b5563"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 229.213031 192.623762 
+L 250.976866 192.623762 
+L 250.976866 192.623762 
+L 229.213031 192.623762 
+z
+" clip-path="url(#pcdef171509)" style="fill: #2563eb"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m8ca0a002df" d="M 0 0 
+       <path id="mfb9895ed98" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8ca0a002df" x="63.598549" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb9895ed98" x="240.094948" y="213.7635" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
-      <!-- corrective -->
-      <g transform="translate(45.17812 210.931827) scale(0.085 -0.085)">
-       <defs>
-        <path id="Helvetica-46" d="M 1703 3444 
-Q 2269 3444 2623 3169 
-Q 2978 2894 3050 2222 
-L 2503 2222 
-Q 2453 2531 2275 2736 
-Q 2097 2941 1703 2941 
-Q 1166 2941 934 2416 
-Q 784 2075 784 1575 
-Q 784 1072 996 728 
-Q 1209 384 1666 384 
-Q 2016 384 2220 598 
-Q 2425 813 2503 1184 
-L 3050 1184 
-Q 2956 519 2581 211 
-Q 2206 -97 1622 -97 
-Q 966 -97 575 383 
-Q 184 863 184 1581 
-Q 184 2463 612 2953 
-Q 1041 3444 1703 3444 
-z
-M 1616 3428 
-L 1616 3428 
-z
-" transform="scale(0.015625)"/>
-        <path id="Helvetica-52" d="M 1741 363 
-Q 2300 363 2508 786 
-Q 2716 1209 2716 1728 
-Q 2716 2197 2566 2491 
-Q 2328 2953 1747 2953 
-Q 1231 2953 997 2559 
-Q 763 2166 763 1609 
-Q 763 1075 997 719 
-Q 1231 363 1741 363 
-z
-M 1763 3444 
-Q 2409 3444 2856 3012 
-Q 3303 2581 3303 1744 
-Q 3303 934 2909 406 
-Q 2516 -122 1688 -122 
-Q 997 -122 590 345 
-Q 184 813 184 1600 
-Q 184 2444 612 2944 
-Q 1041 3444 1763 3444 
-z
-M 1744 3428 
-L 1744 3428 
-z
-" transform="scale(0.015625)"/>
-        <path id="Helvetica-55" d="M 428 3347 
-L 963 3347 
-L 963 2769 
-Q 1028 2938 1284 3180 
-Q 1541 3422 1875 3422 
-Q 1891 3422 1928 3419 
-Q 1966 3416 2056 3406 
-L 2056 2813 
-Q 2006 2822 1964 2825 
-Q 1922 2828 1872 2828 
-Q 1447 2828 1219 2554 
-Q 991 2281 991 1925 
-L 991 0 
-L 428 0 
-L 428 3347 
-z
-" transform="scale(0.015625)"/>
-        <path id="Helvetica-48" d="M 1806 3422 
-Q 2163 3422 2497 3255 
-Q 2831 3088 3006 2822 
-Q 3175 2569 3231 2231 
-Q 3281 2000 3281 1494 
-L 828 1494 
-Q 844 984 1069 676 
-Q 1294 369 1766 369 
-Q 2206 369 2469 659 
-Q 2619 828 2681 1050 
-L 3234 1050 
-Q 3213 866 3089 639 
-Q 2966 413 2813 269 
-Q 2556 19 2178 -69 
-Q 1975 -119 1719 -119 
-Q 1094 -119 659 336 
-Q 225 791 225 1609 
-Q 225 2416 662 2919 
-Q 1100 3422 1806 3422 
-z
-M 2703 1941 
-Q 2669 2306 2544 2525 
-Q 2313 2931 1772 2931 
-Q 1384 2931 1121 2651 
-Q 859 2372 844 1941 
-L 2703 1941 
-z
-M 1753 3428 
-L 1753 3428 
-z
-" transform="scale(0.015625)"/>
-        <path id="Helvetica-57" d="M 525 4281 
-L 1094 4281 
-L 1094 3347 
-L 1628 3347 
-L 1628 2888 
-L 1094 2888 
-L 1094 703 
-Q 1094 528 1213 469 
-Q 1278 434 1431 434 
-Q 1472 434 1519 436 
-Q 1566 438 1628 444 
-L 1628 0 
-Q 1531 -28 1426 -40 
-Q 1322 -53 1200 -53 
-Q 806 -53 665 148 
-Q 525 350 525 672 
-L 525 2888 
-L 72 2888 
-L 72 3347 
-L 525 3347 
-L 525 4281 
-z
-" transform="scale(0.015625)"/>
-        <path id="Helvetica-4c" d="M 413 3331 
-L 984 3331 
-L 984 0 
-L 413 0 
-L 413 3331 
-z
-M 413 4591 
-L 984 4591 
-L 984 3953 
-L 413 3953 
-L 413 4591 
-z
-" transform="scale(0.015625)"/>
-        <path id="Helvetica-59" d="M 688 3347 
-L 1581 622 
-L 2516 3347 
-L 3131 3347 
-L 1869 0 
-L 1269 0 
-L 34 3347 
-L 688 3347 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#Helvetica-46"/>
-       <use xlink:href="#Helvetica-52" transform="translate(50 0)"/>
-       <use xlink:href="#Helvetica-55" transform="translate(105.609375 0)"/>
-       <use xlink:href="#Helvetica-55" transform="translate(138.90625 0)"/>
-       <use xlink:href="#Helvetica-48" transform="translate(172.203125 0)"/>
-       <use xlink:href="#Helvetica-46" transform="translate(227.8125 0)"/>
-       <use xlink:href="#Helvetica-57" transform="translate(277.8125 0)"/>
-       <use xlink:href="#Helvetica-4c" transform="translate(305.59375 0)"/>
-       <use xlink:href="#Helvetica-59" transform="translate(327.8125 0)"/>
-       <use xlink:href="#Helvetica-48" transform="translate(377.8125 0)"/>
-      </g>
-      <!-- negation -->
-      <g transform="translate(47.293159 219.004337) scale(0.085 -0.085)">
-       <defs>
-        <path id="Helvetica-51" d="M 413 3347 
-L 947 3347 
-L 947 2872 
-Q 1184 3166 1450 3294 
-Q 1716 3422 2041 3422 
-Q 2753 3422 3003 2925 
-Q 3141 2653 3141 2147 
-L 3141 0 
-L 2569 0 
-L 2569 2109 
-Q 2569 2416 2478 2603 
-Q 2328 2916 1934 2916 
-Q 1734 2916 1606 2875 
-Q 1375 2806 1200 2600 
-Q 1059 2434 1017 2257 
-Q 975 2081 975 1753 
-L 975 0 
-L 413 0 
-L 413 3347 
-z
-M 1734 3428 
-L 1734 3428 
-z
-" transform="scale(0.015625)"/>
-        <path id="Helvetica-4a" d="M 1594 3406 
-Q 1988 3406 2281 3213 
-Q 2441 3103 2606 2894 
-L 2606 3316 
-L 3125 3316 
-L 3125 272 
-Q 3125 -366 2938 -734 
-Q 2588 -1416 1616 -1416 
-Q 1075 -1416 706 -1173 
-Q 338 -931 294 -416 
-L 866 -416 
-Q 906 -641 1028 -763 
-Q 1219 -950 1628 -950 
-Q 2275 -950 2475 -494 
-Q 2594 -225 2584 466 
-Q 2416 209 2178 84 
-Q 1941 -41 1550 -41 
-Q 1006 -41 598 345 
-Q 191 731 191 1622 
-Q 191 2463 602 2934 
-Q 1013 3406 1594 3406 
-z
-M 2606 1688 
-Q 2606 2309 2350 2609 
-Q 2094 2909 1697 2909 
-Q 1103 2909 884 2353 
-Q 769 2056 769 1575 
-Q 769 1009 998 714 
-Q 1228 419 1616 419 
-Q 2222 419 2469 966 
-Q 2606 1275 2606 1688 
-z
-M 1659 3428 
-L 1659 3428 
-z
-" transform="scale(0.015625)"/>
-        <path id="Helvetica-44" d="M 844 891 
-Q 844 647 1022 506 
-Q 1200 366 1444 366 
-Q 1741 366 2019 503 
-Q 2488 731 2488 1250 
-L 2488 1703 
-Q 2384 1638 2221 1594 
-Q 2059 1550 1903 1531 
-L 1563 1488 
-Q 1256 1447 1103 1359 
-Q 844 1213 844 891 
-z
-M 2206 2028 
-Q 2400 2053 2466 2191 
-Q 2503 2266 2503 2406 
-Q 2503 2694 2298 2823 
-Q 2094 2953 1713 2953 
-Q 1272 2953 1088 2716 
-Q 984 2584 953 2325 
-L 428 2325 
-Q 444 2944 830 3186 
-Q 1216 3428 1725 3428 
-Q 2316 3428 2684 3203 
-Q 3050 2978 3050 2503 
-L 3050 575 
-Q 3050 488 3086 434 
-Q 3122 381 3238 381 
-Q 3275 381 3322 386 
-Q 3369 391 3422 400 
-L 3422 -16 
-Q 3291 -53 3222 -62 
-Q 3153 -72 3034 -72 
-Q 2744 -72 2613 134 
-Q 2544 244 2516 444 
-Q 2344 219 2022 53 
-Q 1700 -113 1313 -113 
-Q 847 -113 551 170 
-Q 256 453 256 878 
-Q 256 1344 547 1600 
-Q 838 1856 1309 1916 
-L 2206 2028 
-z
-M 1741 3428 
-L 1741 3428 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#Helvetica-51"/>
-       <use xlink:href="#Helvetica-48" transform="translate(55.609375 0)"/>
-       <use xlink:href="#Helvetica-4a" transform="translate(111.21875 0)"/>
-       <use xlink:href="#Helvetica-44" transform="translate(166.828125 0)"/>
-       <use xlink:href="#Helvetica-57" transform="translate(222.4375 0)"/>
-       <use xlink:href="#Helvetica-4c" transform="translate(250.21875 0)"/>
-       <use xlink:href="#Helvetica-52" transform="translate(272.4375 0)"/>
-       <use xlink:href="#Helvetica-51" transform="translate(328.046875 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_2">
-     <g id="line2d_2">
-      <g>
-       <use xlink:href="#m8ca0a002df" x="113.777356" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_2">
-      <!-- rule of -->
-      <g transform="translate(101.96634 210.931827) scale(0.085 -0.085)">
-       <defs>
-        <path id="Helvetica-58" d="M 975 3347 
-L 975 1125 
-Q 975 869 1056 706 
-Q 1206 406 1616 406 
-Q 2203 406 2416 931 
-Q 2531 1213 2531 1703 
-L 2531 3347 
-L 3094 3347 
-L 3094 0 
-L 2563 0 
-L 2569 494 
-Q 2459 303 2297 172 
-Q 1975 -91 1516 -91 
-Q 800 -91 541 388 
-Q 400 644 400 1072 
-L 400 3347 
-L 975 3347 
-z
-M 1747 3428 
-L 1747 3428 
-z
-" transform="scale(0.015625)"/>
-        <path id="Helvetica-4f" d="M 428 4591 
-L 991 4591 
-L 991 0 
-L 428 0 
-L 428 4591 
-z
-" transform="scale(0.015625)"/>
-        <path id="Helvetica-3" transform="scale(0.015625)"/>
-        <path id="Helvetica-49" d="M 553 3856 
-Q 566 4206 675 4369 
-Q 872 4656 1434 4656 
-Q 1488 4656 1544 4653 
-Q 1600 4650 1672 4644 
-L 1672 4131 
-Q 1584 4138 1545 4139 
-Q 1506 4141 1472 4141 
-Q 1216 4141 1166 4008 
-Q 1116 3875 1116 3331 
-L 1672 3331 
-L 1672 2888 
-L 1109 2888 
-L 1109 0 
-L 553 0 
-L 553 2888 
-L 88 2888 
-L 88 3331 
-L 553 3331 
-L 553 3856 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#Helvetica-55"/>
-       <use xlink:href="#Helvetica-58" transform="translate(33.296875 0)"/>
-       <use xlink:href="#Helvetica-4f" transform="translate(88.90625 0)"/>
-       <use xlink:href="#Helvetica-48" transform="translate(111.125 0)"/>
-       <use xlink:href="#Helvetica-3" transform="translate(166.734375 0)"/>
-       <use xlink:href="#Helvetica-52" transform="translate(194.515625 0)"/>
-       <use xlink:href="#Helvetica-49" transform="translate(250.125 0)"/>
-      </g>
-      <!-- three -->
-      <g transform="translate(104.09134 219.004337) scale(0.085 -0.085)">
-       <defs>
-        <path id="Helvetica-4b" d="M 413 4606 
-L 975 4606 
-L 975 2894 
-Q 1175 3147 1334 3250 
-Q 1606 3428 2013 3428 
-Q 2741 3428 3000 2919 
-Q 3141 2641 3141 2147 
-L 3141 0 
-L 2563 0 
-L 2563 2109 
-Q 2563 2478 2469 2650 
-Q 2316 2925 1894 2925 
-Q 1544 2925 1259 2684 
-Q 975 2444 975 1775 
-L 975 0 
-L 413 0 
-L 413 4606 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#Helvetica-57"/>
-       <use xlink:href="#Helvetica-4b" transform="translate(27.78125 0)"/>
-       <use xlink:href="#Helvetica-55" transform="translate(83.390625 0)"/>
-       <use xlink:href="#Helvetica-48" transform="translate(116.6875 0)"/>
-       <use xlink:href="#Helvetica-48" transform="translate(172.296875 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_3">
-     <g id="line2d_3">
-      <g>
-       <use xlink:href="#m8ca0a002df" x="163.956163" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_3">
-      <!-- setup / -->
-      <g transform="translate(151.198858 210.931827) scale(0.085 -0.085)">
-       <defs>
-        <path id="Helvetica-56" d="M 747 1050 
-Q 772 769 888 619 
-Q 1100 347 1625 347 
-Q 1938 347 2175 483 
-Q 2413 619 2413 903 
-Q 2413 1119 2222 1231 
-Q 2100 1300 1741 1391 
-L 1294 1503 
-Q 866 1609 663 1741 
-Q 300 1969 300 2372 
-Q 300 2847 642 3140 
-Q 984 3434 1563 3434 
-Q 2319 3434 2653 2991 
-Q 2863 2709 2856 2384 
-L 2325 2384 
-Q 2309 2575 2191 2731 
-Q 1997 2953 1519 2953 
-Q 1200 2953 1036 2831 
-Q 872 2709 872 2509 
-Q 872 2291 1088 2159 
-Q 1213 2081 1456 2022 
-L 1828 1931 
-Q 2434 1784 2641 1647 
-Q 2969 1431 2969 969 
-Q 2969 522 2630 197 
-Q 2291 -128 1597 -128 
-Q 850 -128 539 211 
-Q 228 550 206 1050 
-L 747 1050 
-z
-M 1578 3428 
-L 1578 3428 
-z
-" transform="scale(0.015625)"/>
-        <path id="Helvetica-53" d="M 1825 378 
-Q 2219 378 2480 708 
-Q 2741 1038 2741 1694 
-Q 2741 2094 2625 2381 
-Q 2406 2934 1825 2934 
-Q 1241 2934 1025 2350 
-Q 909 2038 909 1556 
-Q 909 1169 1025 897 
-Q 1244 378 1825 378 
-z
-M 369 3331 
-L 916 3331 
-L 916 2888 
-Q 1084 3116 1284 3241 
-Q 1569 3428 1953 3428 
-Q 2522 3428 2919 2992 
-Q 3316 2556 3316 1747 
-Q 3316 653 2744 184 
-Q 2381 -113 1900 -113 
-Q 1522 -113 1266 53 
-Q 1116 147 931 375 
-L 931 -1334 
-L 369 -1334 
-L 369 3331 
-z
-" transform="scale(0.015625)"/>
-        <path id="Helvetica-12" d="M 1456 4591 
-L 1931 4591 
-L 475 0 
-L 0 0 
-L 1456 4591 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#Helvetica-56"/>
-       <use xlink:href="#Helvetica-48" transform="translate(50 0)"/>
-       <use xlink:href="#Helvetica-57" transform="translate(105.609375 0)"/>
-       <use xlink:href="#Helvetica-58" transform="translate(133.390625 0)"/>
-       <use xlink:href="#Helvetica-53" transform="translate(189 0)"/>
-       <use xlink:href="#Helvetica-3" transform="translate(244.609375 0)"/>
-       <use xlink:href="#Helvetica-12" transform="translate(272.390625 0)"/>
-      </g>
-      <!-- payoff -->
-      <g transform="translate(152.453936 219.331719) scale(0.085 -0.085)">
-       <defs>
-        <path id="Helvetica-5c" d="M 2503 3347 
-L 3125 3347 
-Q 3006 3025 2597 1878 
-Q 2291 1016 2084 472 
-Q 1597 -809 1397 -1090 
-Q 1197 -1372 709 -1372 
-Q 591 -1372 527 -1362 
-Q 463 -1353 369 -1328 
-L 369 -816 
-Q 516 -856 581 -865 
-Q 647 -875 697 -875 
-Q 853 -875 926 -823 
-Q 1000 -772 1050 -697 
-Q 1066 -672 1162 -440 
-Q 1259 -209 1303 -97 
-L 66 3347 
-L 703 3347 
-L 1600 622 
-L 2503 3347 
-z
-M 1597 3428 
-L 1597 3428 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#Helvetica-53"/>
-       <use xlink:href="#Helvetica-44" transform="translate(55.609375 0)"/>
-       <use xlink:href="#Helvetica-5c" transform="translate(111.21875 0)"/>
-       <use xlink:href="#Helvetica-52" transform="translate(161.21875 0)"/>
-       <use xlink:href="#Helvetica-49" transform="translate(216.828125 0)"/>
-       <use xlink:href="#Helvetica-49" transform="translate(242.859375 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_4">
-     <g id="line2d_4">
-      <g>
-       <use xlink:href="#m8ca0a002df" x="214.13497" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_4">
-      <!-- landing -->
-      <g transform="translate(200.429384 210.931827) scale(0.085 -0.085)">
-       <defs>
-        <path id="Helvetica-47" d="M 769 1634 
-Q 769 1097 997 734 
-Q 1225 372 1728 372 
-Q 2119 372 2370 708 
-Q 2622 1044 2622 1672 
-Q 2622 2306 2362 2611 
-Q 2103 2916 1722 2916 
-Q 1297 2916 1033 2591 
-Q 769 2266 769 1634 
-z
-M 1616 3406 
-Q 2000 3406 2259 3244 
-Q 2409 3150 2600 2916 
-L 2600 4606 
-L 3141 4606 
-L 3141 0 
-L 2634 0 
-L 2634 466 
-Q 2438 156 2169 18 
-Q 1900 -119 1553 -119 
-Q 994 -119 584 351 
-Q 175 822 175 1603 
-Q 175 2334 548 2870 
-Q 922 3406 1616 3406 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#Helvetica-4f"/>
-       <use xlink:href="#Helvetica-44" transform="translate(22.21875 0)"/>
-       <use xlink:href="#Helvetica-51" transform="translate(77.828125 0)"/>
-       <use xlink:href="#Helvetica-47" transform="translate(133.4375 0)"/>
-       <use xlink:href="#Helvetica-4c" transform="translate(189.046875 0)"/>
-       <use xlink:href="#Helvetica-51" transform="translate(211.265625 0)"/>
-       <use xlink:href="#Helvetica-4a" transform="translate(266.875 0)"/>
-      </g>
-      <!-- sentence -->
-      <g transform="translate(196.887274 219.440626) scale(0.085 -0.085)">
-       <use xlink:href="#Helvetica-56"/>
-       <use xlink:href="#Helvetica-48" transform="translate(50 0)"/>
-       <use xlink:href="#Helvetica-51" transform="translate(105.609375 0)"/>
-       <use xlink:href="#Helvetica-57" transform="translate(161.21875 0)"/>
-       <use xlink:href="#Helvetica-48" transform="translate(189 0)"/>
-       <use xlink:href="#Helvetica-51" transform="translate(244.609375 0)"/>
-       <use xlink:href="#Helvetica-46" transform="translate(300.21875 0)"/>
-       <use xlink:href="#Helvetica-48" transform="translate(350.21875 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_5">
-     <g id="line2d_5">
-      <g>
-       <use xlink:href="#m8ca0a002df" x="264.313776" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_5">
-      <!-- contrast / -->
-      <g transform="translate(246.835651 210.931827) scale(0.085 -0.085)">
-       <use xlink:href="#Helvetica-46"/>
-       <use xlink:href="#Helvetica-52" transform="translate(50 0)"/>
-       <use xlink:href="#Helvetica-51" transform="translate(105.609375 0)"/>
-       <use xlink:href="#Helvetica-57" transform="translate(161.21875 0)"/>
-       <use xlink:href="#Helvetica-55" transform="translate(189 0)"/>
-       <use xlink:href="#Helvetica-44" transform="translate(222.296875 0)"/>
-       <use xlink:href="#Helvetica-56" transform="translate(277.90625 0)"/>
-       <use xlink:href="#Helvetica-57" transform="translate(327.90625 0)"/>
-       <use xlink:href="#Helvetica-3" transform="translate(355.6875 0)"/>
-       <use xlink:href="#Helvetica-12" transform="translate(383.46875 0)"/>
-      </g>
-      <!-- anaphora -->
-      <g transform="translate(246.35487 219.004337) scale(0.085 -0.085)">
-       <use xlink:href="#Helvetica-44"/>
-       <use xlink:href="#Helvetica-51" transform="translate(55.609375 0)"/>
-       <use xlink:href="#Helvetica-44" transform="translate(111.21875 0)"/>
-       <use xlink:href="#Helvetica-53" transform="translate(166.828125 0)"/>
-       <use xlink:href="#Helvetica-4b" transform="translate(222.4375 0)"/>
-       <use xlink:href="#Helvetica-52" transform="translate(278.046875 0)"/>
-       <use xlink:href="#Helvetica-55" transform="translate(333.65625 0)"/>
-       <use xlink:href="#Helvetica-44" transform="translate(366.953125 0)"/>
-      </g>
-     </g>
-    </g>
-   </g>
-   <g id="matplotlib.axis_2">
-    <g id="ytick_1">
-     <g id="line2d_6">
-      <defs>
-       <path id="me15a2e6f0d" d="M 0 0 
-L -3.5 0 
-" style="stroke: #000000; stroke-width: 0.8"/>
-      </defs>
-      <g>
-       <use xlink:href="#me15a2e6f0d" x="32.588047" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_6">
       <!-- 0 -->
-      <g transform="translate(20.305156 200.99274) scale(0.095 -0.095)">
+      <g transform="translate(237.453503 227.8885) scale(0.095 -0.095)">
        <defs>
         <path id="Helvetica-13" d="M 1731 4475 
 Q 2600 4475 2988 3759 
@@ -767,41 +175,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_2">
-     <g id="line2d_7">
+    <g id="xtick_2">
+     <g id="line2d_2">
       <g>
-       <use xlink:href="#me15a2e6f0d" x="32.588047" y="176.615222" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb9895ed98" x="294.504535" y="213.7635" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_7">
-      <!-- 1 -->
-      <g transform="translate(20.305156 180.177722) scale(0.095 -0.095)">
-       <defs>
-        <path id="Helvetica-14" d="M 613 3169 
-L 613 3600 
-Q 1222 3659 1462 3798 
-Q 1703 3938 1822 4456 
-L 2266 4456 
-L 2266 0 
-L 1666 0 
-L 1666 3169 
-L 613 3169 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#Helvetica-14"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_3">
-     <g id="line2d_8">
-      <g>
-       <use xlink:href="#me15a2e6f0d" x="32.588047" y="155.800204" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_8">
+     <g id="text_2">
       <!-- 2 -->
-      <g transform="translate(20.305156 159.362704) scale(0.095 -0.095)">
+      <g transform="translate(291.863089 227.8885) scale(0.095 -0.095)">
        <defs>
         <path id="Helvetica-15" d="M 200 0 
 Q 231 578 439 1006 
@@ -833,64 +215,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_4">
-     <g id="line2d_9">
+    <g id="xtick_3">
+     <g id="line2d_3">
       <g>
-       <use xlink:href="#me15a2e6f0d" x="32.588047" y="134.985186" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb9895ed98" x="348.914121" y="213.7635" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_9">
-      <!-- 3 -->
-      <g transform="translate(20.305156 138.547686) scale(0.095 -0.095)">
-       <defs>
-        <path id="Helvetica-16" d="M 1663 -122 
-Q 869 -122 511 314 
-Q 153 750 153 1375 
-L 741 1375 
-Q 778 941 903 744 
-Q 1122 391 1694 391 
-Q 2138 391 2406 628 
-Q 2675 866 2675 1241 
-Q 2675 1703 2392 1887 
-Q 2109 2072 1606 2072 
-Q 1550 2072 1492 2070 
-Q 1434 2069 1375 2066 
-L 1375 2563 
-Q 1463 2553 1522 2550 
-Q 1581 2547 1650 2547 
-Q 1966 2547 2169 2647 
-Q 2525 2822 2525 3272 
-Q 2525 3606 2287 3787 
-Q 2050 3969 1734 3969 
-Q 1172 3969 956 3594 
-Q 838 3388 822 3006 
-L 266 3006 
-Q 266 3506 466 3856 
-Q 809 4481 1675 4481 
-Q 2359 4481 2734 4176 
-Q 3109 3872 3109 3294 
-Q 3109 2881 2888 2625 
-Q 2750 2466 2531 2375 
-Q 2884 2278 3082 2001 
-Q 3281 1725 3281 1325 
-Q 3281 684 2859 281 
-Q 2438 -122 1663 -122 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#Helvetica-16"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_10">
-      <g>
-       <use xlink:href="#me15a2e6f0d" x="32.588047" y="114.170168" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_10">
+     <g id="text_3">
       <!-- 4 -->
-      <g transform="translate(20.305156 117.732668) scale(0.095 -0.095)">
+      <g transform="translate(346.272676 227.8885) scale(0.095 -0.095)">
        <defs>
         <path id="Helvetica-17" d="M 2116 1584 
 L 2116 3613 
@@ -916,56 +249,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_6">
-     <g id="line2d_11">
+    <g id="xtick_4">
+     <g id="line2d_4">
       <g>
-       <use xlink:href="#me15a2e6f0d" x="32.588047" y="93.35515" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb9895ed98" x="403.323707" y="213.7635" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_11">
-      <!-- 5 -->
-      <g transform="translate(20.305156 96.91765) scale(0.095 -0.095)">
-       <defs>
-        <path id="Helvetica-18" d="M 791 1141 
-Q 847 659 1238 475 
-Q 1438 381 1700 381 
-Q 2200 381 2440 700 
-Q 2681 1019 2681 1406 
-Q 2681 1875 2395 2131 
-Q 2109 2388 1709 2388 
-Q 1419 2388 1211 2275 
-Q 1003 2163 856 1963 
-L 369 1991 
-L 709 4400 
-L 3034 4400 
-L 3034 3856 
-L 1131 3856 
-L 941 2613 
-Q 1097 2731 1238 2791 
-Q 1488 2894 1816 2894 
-Q 2431 2894 2859 2497 
-Q 3288 2100 3288 1491 
-Q 3288 856 2895 371 
-Q 2503 -113 1644 -113 
-Q 1097 -113 676 195 
-Q 256 503 206 1141 
-L 791 1141 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#Helvetica-18"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_7">
-     <g id="line2d_12">
-      <g>
-       <use xlink:href="#me15a2e6f0d" x="32.588047" y="72.540132" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_12">
+     <g id="text_4">
       <!-- 6 -->
-      <g transform="translate(20.305156 76.102632) scale(0.095 -0.095)">
+      <g transform="translate(400.682262 227.8885) scale(0.095 -0.095)">
        <defs>
         <path id="Helvetica-19" d="M 1872 4494 
 Q 2622 4494 2917 4105 
@@ -1002,44 +294,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_8">
-     <g id="line2d_13">
+    <g id="xtick_5">
+     <g id="line2d_5">
       <g>
-       <use xlink:href="#me15a2e6f0d" x="32.588047" y="51.725114" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb9895ed98" x="457.733294" y="213.7635" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_13">
-      <!-- 7 -->
-      <g transform="translate(20.305156 55.287614) scale(0.095 -0.095)">
-       <defs>
-        <path id="Helvetica-1a" d="M 3347 4400 
-L 3347 3909 
-Q 3131 3700 2773 3181 
-Q 2416 2663 2141 2063 
-Q 1869 1478 1728 997 
-Q 1638 688 1494 0 
-L 872 0 
-Q 1084 1281 1809 2550 
-Q 2238 3294 2709 3834 
-L 234 3834 
-L 234 4400 
-L 3347 4400 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#Helvetica-1a"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_9">
-     <g id="line2d_14">
-      <g>
-       <use xlink:href="#me15a2e6f0d" x="32.588047" y="30.910096" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_14">
+     <g id="text_5">
       <!-- 8 -->
-      <g transform="translate(20.305156 34.472596) scale(0.095 -0.095)">
+      <g transform="translate(455.091848 227.8885) scale(0.095 -0.095)">
        <defs>
         <path id="Helvetica-1b" d="M 1741 2600 
 Q 2113 2600 2322 2808 
@@ -1085,9 +348,251 @@ z
       </g>
      </g>
     </g>
-    <g id="text_15">
+    <g id="text_6">
      <!-- devices per 100 sentences -->
-     <g transform="translate(14.325 165.230459) rotate(-90) scale(0.095 -0.095)">
+     <g transform="translate(296.804523 240.627758) scale(0.095 -0.095)">
+      <defs>
+       <path id="Helvetica-47" d="M 769 1634 
+Q 769 1097 997 734 
+Q 1225 372 1728 372 
+Q 2119 372 2370 708 
+Q 2622 1044 2622 1672 
+Q 2622 2306 2362 2611 
+Q 2103 2916 1722 2916 
+Q 1297 2916 1033 2591 
+Q 769 2266 769 1634 
+z
+M 1616 3406 
+Q 2000 3406 2259 3244 
+Q 2409 3150 2600 2916 
+L 2600 4606 
+L 3141 4606 
+L 3141 0 
+L 2634 0 
+L 2634 466 
+Q 2438 156 2169 18 
+Q 1900 -119 1553 -119 
+Q 994 -119 584 351 
+Q 175 822 175 1603 
+Q 175 2334 548 2870 
+Q 922 3406 1616 3406 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-48" d="M 1806 3422 
+Q 2163 3422 2497 3255 
+Q 2831 3088 3006 2822 
+Q 3175 2569 3231 2231 
+Q 3281 2000 3281 1494 
+L 828 1494 
+Q 844 984 1069 676 
+Q 1294 369 1766 369 
+Q 2206 369 2469 659 
+Q 2619 828 2681 1050 
+L 3234 1050 
+Q 3213 866 3089 639 
+Q 2966 413 2813 269 
+Q 2556 19 2178 -69 
+Q 1975 -119 1719 -119 
+Q 1094 -119 659 336 
+Q 225 791 225 1609 
+Q 225 2416 662 2919 
+Q 1100 3422 1806 3422 
+z
+M 2703 1941 
+Q 2669 2306 2544 2525 
+Q 2313 2931 1772 2931 
+Q 1384 2931 1121 2651 
+Q 859 2372 844 1941 
+L 2703 1941 
+z
+M 1753 3428 
+L 1753 3428 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-59" d="M 688 3347 
+L 1581 622 
+L 2516 3347 
+L 3131 3347 
+L 1869 0 
+L 1269 0 
+L 34 3347 
+L 688 3347 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-4c" d="M 413 3331 
+L 984 3331 
+L 984 0 
+L 413 0 
+L 413 3331 
+z
+M 413 4591 
+L 984 4591 
+L 984 3953 
+L 413 3953 
+L 413 4591 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-46" d="M 1703 3444 
+Q 2269 3444 2623 3169 
+Q 2978 2894 3050 2222 
+L 2503 2222 
+Q 2453 2531 2275 2736 
+Q 2097 2941 1703 2941 
+Q 1166 2941 934 2416 
+Q 784 2075 784 1575 
+Q 784 1072 996 728 
+Q 1209 384 1666 384 
+Q 2016 384 2220 598 
+Q 2425 813 2503 1184 
+L 3050 1184 
+Q 2956 519 2581 211 
+Q 2206 -97 1622 -97 
+Q 966 -97 575 383 
+Q 184 863 184 1581 
+Q 184 2463 612 2953 
+Q 1041 3444 1703 3444 
+z
+M 1616 3428 
+L 1616 3428 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-56" d="M 747 1050 
+Q 772 769 888 619 
+Q 1100 347 1625 347 
+Q 1938 347 2175 483 
+Q 2413 619 2413 903 
+Q 2413 1119 2222 1231 
+Q 2100 1300 1741 1391 
+L 1294 1503 
+Q 866 1609 663 1741 
+Q 300 1969 300 2372 
+Q 300 2847 642 3140 
+Q 984 3434 1563 3434 
+Q 2319 3434 2653 2991 
+Q 2863 2709 2856 2384 
+L 2325 2384 
+Q 2309 2575 2191 2731 
+Q 1997 2953 1519 2953 
+Q 1200 2953 1036 2831 
+Q 872 2709 872 2509 
+Q 872 2291 1088 2159 
+Q 1213 2081 1456 2022 
+L 1828 1931 
+Q 2434 1784 2641 1647 
+Q 2969 1431 2969 969 
+Q 2969 522 2630 197 
+Q 2291 -128 1597 -128 
+Q 850 -128 539 211 
+Q 228 550 206 1050 
+L 747 1050 
+z
+M 1578 3428 
+L 1578 3428 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-3" transform="scale(0.015625)"/>
+       <path id="Helvetica-53" d="M 1825 378 
+Q 2219 378 2480 708 
+Q 2741 1038 2741 1694 
+Q 2741 2094 2625 2381 
+Q 2406 2934 1825 2934 
+Q 1241 2934 1025 2350 
+Q 909 2038 909 1556 
+Q 909 1169 1025 897 
+Q 1244 378 1825 378 
+z
+M 369 3331 
+L 916 3331 
+L 916 2888 
+Q 1084 3116 1284 3241 
+Q 1569 3428 1953 3428 
+Q 2522 3428 2919 2992 
+Q 3316 2556 3316 1747 
+Q 3316 653 2744 184 
+Q 2381 -113 1900 -113 
+Q 1522 -113 1266 53 
+Q 1116 147 931 375 
+L 931 -1334 
+L 369 -1334 
+L 369 3331 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-55" d="M 428 3347 
+L 963 3347 
+L 963 2769 
+Q 1028 2938 1284 3180 
+Q 1541 3422 1875 3422 
+Q 1891 3422 1928 3419 
+Q 1966 3416 2056 3406 
+L 2056 2813 
+Q 2006 2822 1964 2825 
+Q 1922 2828 1872 2828 
+Q 1447 2828 1219 2554 
+Q 991 2281 991 1925 
+L 991 0 
+L 428 0 
+L 428 3347 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-14" d="M 613 3169 
+L 613 3600 
+Q 1222 3659 1462 3798 
+Q 1703 3938 1822 4456 
+L 2266 4456 
+L 2266 0 
+L 1666 0 
+L 1666 3169 
+L 613 3169 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-51" d="M 413 3347 
+L 947 3347 
+L 947 2872 
+Q 1184 3166 1450 3294 
+Q 1716 3422 2041 3422 
+Q 2753 3422 3003 2925 
+Q 3141 2653 3141 2147 
+L 3141 0 
+L 2569 0 
+L 2569 2109 
+Q 2569 2416 2478 2603 
+Q 2328 2916 1934 2916 
+Q 1734 2916 1606 2875 
+Q 1375 2806 1200 2600 
+Q 1059 2434 1017 2257 
+Q 975 2081 975 1753 
+L 975 0 
+L 413 0 
+L 413 3347 
+z
+M 1734 3428 
+L 1734 3428 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-57" d="M 525 4281 
+L 1094 4281 
+L 1094 3347 
+L 1628 3347 
+L 1628 2888 
+L 1094 2888 
+L 1094 703 
+Q 1094 528 1213 469 
+Q 1278 434 1431 434 
+Q 1472 434 1519 436 
+Q 1566 438 1628 444 
+L 1628 0 
+Q 1531 -28 1426 -40 
+Q 1322 -53 1200 -53 
+Q 806 -53 665 148 
+Q 525 350 525 672 
+L 525 2888 
+L 72 2888 
+L 72 3347 
+L 525 3347 
+L 525 4281 
+z
+" transform="scale(0.015625)"/>
+      </defs>
       <use xlink:href="#Helvetica-47"/>
       <use xlink:href="#Helvetica-48" transform="translate(55.609375 0)"/>
       <use xlink:href="#Helvetica-59" transform="translate(111.21875 0)"/>
@@ -1116,19 +621,15 @@ z
      </g>
     </g>
    </g>
-   <g id="patch_13">
-    <path d="M 32.588047 197.43024 
-L 32.588047 20.02224 
+   <g id="matplotlib.axis_2"/>
+   <g id="patch_15">
+    <path d="M 240.094948 213.7635 
+L 466.522534 213.7635 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_14">
-    <path d="M 32.588047 197.43024 
-L 295.324279 197.43024 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="text_16">
+   <g id="text_7">
     <!-- 6.2 -->
-    <g style="fill: #4b5563" transform="translate(48.504576 66.215569) scale(0.08 -0.08)">
+    <g style="fill: #4b5563" transform="translate(410.229539 47.670564) scale(0.08 -0.08)">
      <defs>
       <path id="Helvetica-11" d="M 547 681 
 L 1200 681 
@@ -1143,119 +644,198 @@ z
      <use xlink:href="#Helvetica-15" transform="translate(83.390625 0)"/>
     </g>
    </g>
-   <g id="text_17">
-    <!-- 6.9 -->
-    <g style="fill: #4b5563" transform="translate(98.683383 50.204016) scale(0.08 -0.08)">
+   <g id="text_8">
+    <!-- 0 -->
+    <g style="fill: #2563eb" transform="translate(242.815428 60.354407) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-13"/>
+    </g>
+   </g>
+   <g id="text_9">
+    <!-- corrective negation -->
+    <g style="fill: #111827" transform="translate(150.274375 48.449753) scale(0.09 -0.09)">
      <defs>
-      <path id="Helvetica-1c" d="M 850 1081 
-Q 875 616 1209 438 
-Q 1381 344 1597 344 
-Q 2000 344 2284 680 
-Q 2569 1016 2688 2044 
-Q 2500 1747 2223 1626 
-Q 1947 1506 1628 1506 
-Q 981 1506 604 1909 
-Q 228 2313 228 2947 
-Q 228 3556 600 4018 
-Q 972 4481 1697 4481 
-Q 2675 4481 3047 3600 
-Q 3253 3116 3253 2388 
-Q 3253 1566 3006 931 
-Q 2597 -125 1619 -125 
-Q 963 -125 622 219 
-Q 281 563 281 1081 
-L 850 1081 
-z
-M 1703 2000 
-Q 2038 2000 2314 2220 
-Q 2591 2441 2591 2991 
-Q 2591 3484 2342 3726 
-Q 2094 3969 1709 3969 
-Q 1297 3969 1055 3692 
-Q 813 3416 813 2953 
-Q 813 2516 1025 2258 
-Q 1238 2000 1703 2000 
+      <path id="Helvetica-Bold-46" d="M 3363 2184 
+L 2450 2184 
+Q 2425 2375 2322 2528 
+Q 2172 2734 1856 2734 
+Q 1406 2734 1241 2288 
+Q 1153 2050 1153 1656 
+Q 1153 1281 1241 1053 
+Q 1400 628 1841 628 
+Q 2153 628 2284 797 
+Q 2416 966 2444 1234 
+L 3353 1234 
+Q 3322 828 3059 466 
+Q 2641 -119 1819 -119 
+Q 997 -119 609 368 
+Q 222 856 222 1634 
+Q 222 2513 650 3000 
+Q 1078 3488 1831 3488 
+Q 2472 3488 2880 3200 
+Q 3288 2913 3363 2184 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#Helvetica-19"/>
-     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
-     <use xlink:href="#Helvetica-1c" transform="translate(83.390625 0)"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- 6.2 -->
-    <g style="fill: #4b5563" transform="translate(148.86219 66.215569) scale(0.08 -0.08)">
-     <use xlink:href="#Helvetica-19"/>
-     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
-     <use xlink:href="#Helvetica-15" transform="translate(83.390625 0)"/>
-    </g>
-   </g>
-   <g id="text_19">
-    <!-- 4.6 -->
-    <g style="fill: #4b5563" transform="translate(199.040996 98.238673) scale(0.08 -0.08)">
-     <use xlink:href="#Helvetica-17"/>
-     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
-     <use xlink:href="#Helvetica-19" transform="translate(83.390625 0)"/>
-    </g>
-   </g>
-   <g id="text_20">
-    <!-- 4.6 -->
-    <g style="fill: #4b5563" transform="translate(249.219803 98.238673) scale(0.08 -0.08)">
-     <use xlink:href="#Helvetica-17"/>
-     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
-     <use xlink:href="#Helvetica-19" transform="translate(83.390625 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- 0 -->
-    <g style="fill: #2563eb" transform="translate(70.908148 194.307987) scale(0.08 -0.08)">
-     <use xlink:href="#Helvetica-13"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- 0 -->
-    <g style="fill: #2563eb" transform="translate(121.086954 194.307987) scale(0.08 -0.08)">
-     <use xlink:href="#Helvetica-13"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- 0 -->
-    <g style="fill: #2563eb" transform="translate(171.265761 194.307987) scale(0.08 -0.08)">
-     <use xlink:href="#Helvetica-13"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 0 -->
-    <g style="fill: #2563eb" transform="translate(221.444568 194.307987) scale(0.08 -0.08)">
-     <use xlink:href="#Helvetica-13"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- 2.6 -->
-    <g style="fill: #2563eb" transform="translate(268.287749 140.936146) scale(0.08 -0.08)">
-     <use xlink:href="#Helvetica-15"/>
-     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
-     <use xlink:href="#Helvetica-19" transform="translate(83.390625 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- (a) -->
-    <g transform="translate(35.215409 14.7) scale(0.1 -0.1)">
-     <defs>
-      <path id="Helvetica-Bold-b" d="M 1394 -1291 
-L 1172 -988 
-Q 956 -713 713 -169 
-Q 278 803 278 1744 
-Q 278 2600 644 3444 
-Q 891 4019 1366 4681 
-L 2038 4681 
-L 1847 4331 
-Q 1453 3609 1300 2819 
-Q 1200 2300 1200 1688 
-Q 1200 731 1478 -72 
-Q 1641 -547 2053 -1291 
-L 1394 -1291 
+      <path id="Helvetica-Bold-52" d="M 3256 2975 
+Q 3688 2434 3688 1697 
+Q 3688 947 3256 414 
+Q 2825 -119 1947 -119 
+Q 1069 -119 637 414 
+Q 206 947 206 1697 
+Q 206 2434 637 2975 
+Q 1069 3516 1947 3516 
+Q 2825 3516 3256 2975 
+z
+M 1944 2763 
+Q 1553 2763 1342 2486 
+Q 1131 2209 1131 1697 
+Q 1131 1184 1342 906 
+Q 1553 628 1944 628 
+Q 2334 628 2543 906 
+Q 2753 1184 2753 1697 
+Q 2753 2209 2543 2486 
+Q 2334 2763 1944 2763 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-55" d="M 2128 2584 
+Q 1591 2584 1406 2234 
+Q 1303 2038 1303 1628 
+L 1303 0 
+L 406 0 
+L 406 3406 
+L 1256 3406 
+L 1256 2813 
+Q 1463 3153 1616 3278 
+Q 1866 3488 2266 3488 
+Q 2291 3488 2308 3486 
+Q 2325 3484 2384 3481 
+L 2384 2569 
+Q 2300 2578 2234 2581 
+Q 2169 2584 2128 2584 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-48" d="M 3331 1000 
+Q 3297 697 3016 384 
+Q 2578 -113 1791 -113 
+Q 1141 -113 644 306 
+Q 147 725 147 1669 
+Q 147 2553 595 3025 
+Q 1044 3497 1759 3497 
+Q 2184 3497 2525 3337 
+Q 2866 3178 3088 2834 
+Q 3288 2531 3347 2131 
+Q 3381 1897 3375 1456 
+L 1044 1456 
+Q 1063 944 1366 738 
+Q 1550 609 1809 609 
+Q 2084 609 2256 766 
+Q 2350 850 2422 1000 
+L 3331 1000 
+z
+M 2450 2044 
+Q 2428 2397 2236 2580 
+Q 2044 2763 1759 2763 
+Q 1450 2763 1279 2569 
+Q 1109 2375 1066 2044 
+L 2450 2044 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-57" d="M 1975 634 
+L 1975 -31 
+L 1553 -47 
+Q 922 -69 691 172 
+Q 541 325 541 644 
+L 541 2741 
+L 66 2741 
+L 66 3375 
+L 541 3375 
+L 541 4325 
+L 1422 4325 
+L 1422 3375 
+L 1975 3375 
+L 1975 2741 
+L 1422 2741 
+L 1422 941 
+Q 1422 731 1475 679 
+Q 1528 628 1800 628 
+Q 1841 628 1886 629 
+Q 1931 631 1975 634 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-4c" d="M 1331 3406 
+L 1331 0 
+L 428 0 
+L 428 3406 
+L 1331 3406 
+z
+M 1331 4634 
+L 1331 3813 
+L 428 3813 
+L 428 4634 
+L 1331 4634 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-59" d="M 81 3406 
+L 1081 3406 
+L 1791 894 
+L 2516 3406 
+L 3472 3406 
+L 2244 0 
+L 1303 0 
+L 81 3406 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-3" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-51" d="M 2019 2747 
+Q 1566 2747 1397 2363 
+Q 1309 2159 1309 1844 
+L 1309 0 
+L 422 0 
+L 422 3400 
+L 1281 3400 
+L 1281 2903 
+Q 1453 3166 1606 3281 
+Q 1881 3488 2303 3488 
+Q 2831 3488 3167 3211 
+Q 3503 2934 3503 2294 
+L 3503 0 
+L 2591 0 
+L 2591 2072 
+Q 2591 2341 2519 2484 
+Q 2388 2747 2019 2747 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-4a" d="M 1378 -597 
+Q 1522 -719 1863 -719 
+Q 2344 -719 2506 -397 
+Q 2613 -191 2613 297 
+L 2613 516 
+Q 2484 297 2338 188 
+Q 2072 -16 1647 -16 
+Q 991 -16 598 445 
+Q 206 906 206 1694 
+Q 206 2453 584 2970 
+Q 963 3488 1656 3488 
+Q 1913 3488 2103 3409 
+Q 2428 3275 2628 2916 
+L 2628 3406 
+L 3494 3406 
+L 3494 175 
+Q 3494 -484 3272 -819 
+Q 2891 -1394 1809 -1394 
+Q 1156 -1394 743 -1137 
+Q 331 -881 288 -372 
+L 1256 -372 
+Q 1294 -528 1378 -597 
+z
+M 1228 1163 
+Q 1409 731 1878 731 
+Q 2191 731 2406 967 
+Q 2622 1203 2622 1719 
+Q 2622 2203 2417 2456 
+Q 2213 2709 1869 2709 
+Q 1400 2709 1222 2269 
+Q 1128 2034 1128 1691 
+Q 1128 1394 1228 1163 
 z
 " transform="scale(0.015625)"/>
       <path id="Helvetica-Bold-44" d="M 544 3038 
@@ -1299,6 +879,1364 @@ Q 1078 1228 1078 972
 Q 1078 744 1206 644 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-Bold-46"/>
+     <use xlink:href="#Helvetica-Bold-52" transform="translate(55.609375 0)"/>
+     <use xlink:href="#Helvetica-Bold-55" transform="translate(116.6875 0)"/>
+     <use xlink:href="#Helvetica-Bold-55" transform="translate(155.609375 0)"/>
+     <use xlink:href="#Helvetica-Bold-48" transform="translate(194.53125 0)"/>
+     <use xlink:href="#Helvetica-Bold-46" transform="translate(250.140625 0)"/>
+     <use xlink:href="#Helvetica-Bold-57" transform="translate(305.75 0)"/>
+     <use xlink:href="#Helvetica-Bold-4c" transform="translate(339.046875 0)"/>
+     <use xlink:href="#Helvetica-Bold-59" transform="translate(366.828125 0)"/>
+     <use xlink:href="#Helvetica-Bold-48" transform="translate(422.4375 0)"/>
+     <use xlink:href="#Helvetica-Bold-3" transform="translate(478.046875 0)"/>
+     <use xlink:href="#Helvetica-Bold-51" transform="translate(505.828125 0)"/>
+     <use xlink:href="#Helvetica-Bold-48" transform="translate(566.90625 0)"/>
+     <use xlink:href="#Helvetica-Bold-4a" transform="translate(622.515625 0)"/>
+     <use xlink:href="#Helvetica-Bold-44" transform="translate(683.59375 0)"/>
+     <use xlink:href="#Helvetica-Bold-57" transform="translate(739.203125 0)"/>
+     <use xlink:href="#Helvetica-Bold-4c" transform="translate(772.5 0)"/>
+     <use xlink:href="#Helvetica-Bold-52" transform="translate(800.28125 0)"/>
+     <use xlink:href="#Helvetica-Bold-51" transform="translate(861.359375 0)"/>
+    </g>
+   </g>
+   <g id="text_10">
+    <!-- "The problem isn’t the AI. The problem is thinking…" -->
+    <g style="fill: #6b7280" transform="translate(48.56625 61.55841) scale(0.08 -0.08)">
+     <defs>
+      <path id="Helvetica-Oblique-5" d="M 2869 4591 
+L 2384 2753 
+L 2006 2753 
+L 2300 4591 
+L 2869 4591 
+z
+M 1797 4591 
+L 1316 2753 
+L 938 2753 
+L 1231 4591 
+L 1797 4591 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-37" d="M 4803 4591 
+L 4688 4044 
+L 3141 4044 
+L 2281 0 
+L 1650 0 
+L 2509 4044 
+L 963 4044 
+L 1078 4591 
+L 4803 4591 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-4b" d="M 1391 4606 
+L 1953 4606 
+L 1588 2894 
+Q 1844 3147 2025 3250 
+Q 2334 3428 2741 3428 
+Q 3469 3428 3619 2919 
+Q 3700 2641 3597 2147 
+L 3141 0 
+L 2563 0 
+L 3009 2109 
+Q 3088 2478 3031 2650 
+Q 2934 2925 2513 2925 
+Q 2163 2925 1828 2684 
+Q 1494 2444 1350 1775 
+L 975 0 
+L 413 0 
+L 1391 4606 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-48" d="M 3603 2822 
+Q 3719 2569 3703 2231 
+Q 3706 2000 3597 1494 
+L 1144 1494 
+Q 1050 984 1211 676 
+Q 1372 369 1844 369 
+Q 2284 369 2606 659 
+Q 2794 828 2903 1050 
+L 3456 1050 
+Q 3394 866 3223 639 
+Q 3053 413 2869 269 
+Q 2559 19 2163 -69 
+Q 1947 -119 1691 -119 
+Q 1066 -119 728 336 
+Q 391 791 566 1609 
+Q 738 2416 1281 2919 
+Q 1825 3422 2531 3422 
+Q 2888 3422 3188 3255 
+Q 3488 3088 3603 2822 
+z
+M 3113 1941 
+Q 3156 2306 3078 2525 
+Q 2934 2931 2394 2931 
+Q 2006 2931 1684 2651 
+Q 1363 2372 1253 1941 
+L 3113 1941 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-3" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-53" d="M 3100 1694 
+Q 3184 2094 3128 2381 
+Q 3028 2934 2447 2934 
+Q 1863 2934 1522 2350 
+Q 1341 2038 1238 1556 
+Q 1156 1169 1216 897 
+Q 1322 378 1903 378 
+Q 2297 378 2628 708 
+Q 2959 1038 3100 1694 
+z
+M 1075 3331 
+L 1622 3331 
+L 1528 2888 
+Q 1744 3116 1972 3241 
+Q 2297 3428 2681 3428 
+Q 3250 3428 3553 2992 
+Q 3856 2556 3684 1747 
+Q 3453 653 2781 184 
+Q 2356 -113 1875 -113 
+Q 1497 -113 1275 53 
+Q 1144 147 1009 375 
+L 647 -1334 
+L 84 -1334 
+L 1075 3331 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-55" d="M 1138 3347 
+L 1672 3347 
+L 1550 2769 
+Q 1650 2938 1958 3180 
+Q 2266 3422 2600 3422 
+Q 2616 3422 2653 3419 
+Q 2691 3416 2778 3406 
+L 2653 2813 
+Q 2603 2822 2562 2825 
+Q 2522 2828 2472 2828 
+Q 2047 2828 1761 2554 
+Q 1475 2281 1397 1925 
+L 991 0 
+L 428 0 
+L 1138 3347 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-52" d="M 3081 1728 
+Q 3181 2197 3094 2491 
+Q 2953 2953 2372 2953 
+Q 1856 2953 1539 2559 
+Q 1222 2166 1103 1609 
+Q 991 1075 1148 719 
+Q 1306 363 1816 363 
+Q 2375 363 2673 786 
+Q 2972 1209 3081 1728 
+z
+M 3672 1744 
+Q 3500 934 2994 406 
+Q 2488 -122 1659 -122 
+Q 969 -122 662 345 
+Q 356 813 522 1600 
+Q 703 2444 1237 2944 
+Q 1772 3444 2494 3444 
+Q 3141 3444 3495 3012 
+Q 3850 2581 3672 1744 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-45" d="M 1347 4606 
+L 1894 4606 
+L 1541 2941 
+Q 1775 3181 2058 3307 
+Q 2341 3434 2641 3434 
+Q 3266 3434 3564 3004 
+Q 3863 2575 3684 1738 
+Q 3516 944 3019 419 
+Q 2522 -106 1841 -106 
+Q 1459 -106 1238 78 
+Q 1103 188 978 428 
+L 888 0 
+L 369 0 
+L 1347 4606 
+z
+M 3103 1709 
+Q 3216 2238 3062 2584 
+Q 2909 2931 2469 2931 
+Q 2084 2931 1734 2647 
+Q 1384 2363 1247 1709 
+Q 1147 1238 1203 944 
+Q 1306 391 1913 391 
+Q 2369 391 2672 753 
+Q 2975 1116 3103 1709 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-4f" d="M 1403 4591 
+L 1966 4591 
+L 991 0 
+L 428 0 
+L 1403 4591 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-50" d="M 1122 3347 
+L 1678 3347 
+L 1578 2872 
+Q 1831 3119 2016 3231 
+Q 2334 3422 2688 3422 
+Q 3088 3422 3291 3225 
+Q 3403 3113 3469 2894 
+Q 3716 3163 3995 3292 
+Q 4275 3422 4591 3422 
+Q 5266 3422 5406 2934 
+Q 5481 2672 5388 2228 
+L 4916 0 
+L 4331 0 
+L 4825 2325 
+Q 4894 2659 4753 2784 
+Q 4613 2909 4372 2909 
+Q 4041 2909 3755 2687 
+Q 3469 2466 3359 1947 
+L 2947 0 
+L 2375 0 
+L 2838 2184 
+Q 2909 2525 2863 2681 
+Q 2784 2916 2434 2916 
+Q 2116 2916 1802 2669 
+Q 1488 2422 1350 1775 
+L 975 0 
+L 413 0 
+L 1122 3347 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-4c" d="M 1119 3331 
+L 1691 3331 
+L 984 0 
+L 413 0 
+L 1119 3331 
+z
+M 1388 4591 
+L 1959 4591 
+L 1822 3953 
+L 1250 3953 
+L 1388 4591 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-56" d="M 969 1050 
+Q 934 769 1019 619 
+Q 1172 347 1697 347 
+Q 2009 347 2276 483 
+Q 2544 619 2603 903 
+Q 2650 1119 2481 1231 
+Q 2375 1300 2034 1391 
+L 1613 1503 
+Q 1206 1609 1031 1741 
+Q 716 1969 803 2372 
+Q 903 2847 1308 3140 
+Q 1713 3434 2291 3434 
+Q 3047 3434 3288 2991 
+Q 3438 2709 3363 2384 
+L 2831 2384 
+Q 2856 2575 2769 2731 
+Q 2622 2953 2144 2953 
+Q 1825 2953 1636 2831 
+Q 1447 2709 1403 2509 
+Q 1356 2291 1544 2159 
+Q 1653 2081 1884 2022 
+L 2238 1931 
+Q 2813 1784 2991 1647 
+Q 3272 1431 3172 969 
+Q 3078 522 2670 197 
+Q 2263 -128 1569 -128 
+Q 822 -128 583 211 
+Q 344 550 428 1050 
+L 969 1050 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-51" d="M 1122 3347 
+L 1656 3347 
+L 1556 2872 
+Q 1856 3166 2148 3294 
+Q 2441 3422 2766 3422 
+Q 3478 3422 3622 2925 
+Q 3703 2653 3597 2147 
+L 3141 0 
+L 2569 0 
+L 3016 2109 
+Q 3081 2416 3031 2603 
+Q 2947 2916 2553 2916 
+Q 2353 2916 2216 2875 
+Q 1969 2806 1750 2600 
+Q 1575 2434 1495 2257 
+Q 1416 2081 1347 1753 
+L 975 0 
+L 413 0 
+L 1122 3347 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-b7" d="M 1222 3256 
+Q 1400 3284 1523 3450 
+Q 1647 3616 1694 3831 
+Q 1700 3853 1701 3870 
+Q 1703 3888 1700 3909 
+L 1359 3909 
+L 1506 4591 
+L 2175 4591 
+L 2041 3963 
+Q 1956 3563 1731 3283 
+Q 1506 3003 1159 2963 
+L 1222 3256 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-57" d="M 1434 4281 
+L 2003 4281 
+L 1803 3347 
+L 2338 3347 
+L 2241 2888 
+L 1706 2888 
+L 1241 703 
+Q 1203 528 1309 469 
+Q 1369 434 1522 434 
+Q 1563 434 1609 436 
+Q 1656 438 1722 444 
+L 1628 0 
+Q 1525 -28 1417 -40 
+Q 1309 -53 1188 -53 
+Q 794 -53 695 148 
+Q 597 350 666 672 
+L 1138 2888 
+L 684 2888 
+L 781 3347 
+L 1234 3347 
+L 1434 4281 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-24" d="M 3241 1881 
+L 2975 3909 
+L 1803 1881 
+L 3241 1881 
+z
+M 2797 4591 
+L 3500 4591 
+L 4191 0 
+L 3509 0 
+L 3334 1375 
+L 1519 1375 
+L 731 0 
+L 94 0 
+L 2797 4591 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-2c" d="M 1603 4591 
+L 2231 4591 
+L 1256 0 
+L 628 0 
+L 1603 4591 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-11" d="M 691 681 
+L 1344 681 
+L 1200 0 
+L 547 0 
+L 691 681 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-4e" d="M 1375 4591 
+L 1916 4591 
+L 1347 1925 
+L 3094 3347 
+L 3813 3347 
+L 2266 2094 
+L 3175 0 
+L 2456 0 
+L 1769 1688 
+L 1206 1256 
+L 941 0 
+L 400 0 
+L 1375 4591 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-4a" d="M 2963 3213 
+Q 3100 3103 3219 2894 
+L 3309 3316 
+L 3828 3316 
+L 3181 272 
+Q 3047 -366 2781 -734 
+Q 2284 -1416 1313 -1416 
+Q 772 -1416 455 -1173 
+Q 138 -931 203 -416 
+L 775 -416 
+Q 769 -641 866 -763 
+Q 1016 -950 1425 -950 
+Q 2072 -950 2369 -494 
+Q 2544 -225 2681 466 
+Q 2459 209 2195 84 
+Q 1931 -41 1541 -41 
+Q 997 -41 670 345 
+Q 344 731 534 1622 
+Q 713 2463 1223 2934 
+Q 1734 3406 2316 3406 
+Q 2709 3406 2963 3213 
+z
+M 2313 2909 
+Q 1719 2909 1384 2353 
+Q 1203 2056 1103 1575 
+Q 981 1009 1148 714 
+Q 1316 419 1703 419 
+Q 2309 419 2672 966 
+Q 2875 1275 2963 1688 
+Q 3097 2309 2903 2609 
+Q 2709 2909 2313 2909 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-ab" d="M 2872 0 
+L 3016 688 
+L 3669 688 
+L 3525 0 
+L 2872 0 
+z
+M 884 688 
+L 1534 688 
+L 1391 0 
+L 741 0 
+L 884 688 
+z
+M 5006 0 
+L 5150 688 
+L 5800 688 
+L 5656 0 
+L 5006 0 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-Oblique-5"/>
+     <use xlink:href="#Helvetica-Oblique-37" transform="translate(35.5 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4b" transform="translate(96.578125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(152.1875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(207.796875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-53" transform="translate(235.578125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-55" transform="translate(291.1875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-52" transform="translate(324.484375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-45" transform="translate(380.09375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4f" transform="translate(435.703125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(457.921875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-50" transform="translate(513.53125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(596.828125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4c" transform="translate(624.609375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-56" transform="translate(646.828125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-51" transform="translate(696.828125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-b7" transform="translate(752.4375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(774.65625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(802.4375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(830.21875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4b" transform="translate(858 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(913.609375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(969.21875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-24" transform="translate(991.53125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-2c" transform="translate(1058.234375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-11" transform="translate(1086.015625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1113.796875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-37" transform="translate(1139.828125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4b" transform="translate(1200.90625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(1256.515625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1312.125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-53" transform="translate(1339.90625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-55" transform="translate(1395.515625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-52" transform="translate(1428.8125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-45" transform="translate(1484.421875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4f" transform="translate(1540.03125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(1562.25 0)"/>
+     <use xlink:href="#Helvetica-Oblique-50" transform="translate(1617.859375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1701.15625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4c" transform="translate(1728.9375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-56" transform="translate(1751.15625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1801.15625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(1828.9375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4b" transform="translate(1856.71875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4c" transform="translate(1912.328125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-51" transform="translate(1934.546875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4e" transform="translate(1990.15625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4c" transform="translate(2040.15625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-51" transform="translate(2062.375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4a" transform="translate(2117.984375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-ab" transform="translate(2173.59375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-5" transform="translate(2273.59375 0)"/>
+    </g>
+   </g>
+   <g id="text_11">
+    <!-- 6.9 -->
+    <g style="fill: #4b5563" transform="translate(431.156303 82.903461) scale(0.08 -0.08)">
+     <defs>
+      <path id="Helvetica-1c" d="M 850 1081 
+Q 875 616 1209 438 
+Q 1381 344 1597 344 
+Q 2000 344 2284 680 
+Q 2569 1016 2688 2044 
+Q 2500 1747 2223 1626 
+Q 1947 1506 1628 1506 
+Q 981 1506 604 1909 
+Q 228 2313 228 2947 
+Q 228 3556 600 4018 
+Q 972 4481 1697 4481 
+Q 2675 4481 3047 3600 
+Q 3253 3116 3253 2388 
+Q 3253 1566 3006 931 
+Q 2597 -125 1619 -125 
+Q 963 -125 622 219 
+Q 281 563 281 1081 
+L 850 1081 
+z
+M 1703 2000 
+Q 2038 2000 2314 2220 
+Q 2591 2441 2591 2991 
+Q 2591 3484 2342 3726 
+Q 2094 3969 1709 3969 
+Q 1297 3969 1055 3692 
+Q 813 3416 813 2953 
+Q 813 2516 1025 2258 
+Q 1238 2000 1703 2000 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-19"/>
+     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+     <use xlink:href="#Helvetica-1c" transform="translate(83.390625 0)"/>
+    </g>
+   </g>
+   <g id="text_12">
+    <!-- 0 -->
+    <g style="fill: #2563eb" transform="translate(242.815428 95.587304) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-13"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- rule of three -->
+    <g style="fill: #111827" transform="translate(181.287813 83.898158) scale(0.09 -0.09)">
+     <defs>
+      <path id="Helvetica-Bold-58" d="M 2600 481 
+Q 2588 466 2538 387 
+Q 2488 309 2419 250 
+Q 2209 63 2014 -6 
+Q 1819 -75 1556 -75 
+Q 800 -75 538 469 
+Q 391 769 391 1353 
+L 391 3406 
+L 1303 3406 
+L 1303 1353 
+Q 1303 1063 1372 916 
+Q 1494 656 1850 656 
+Q 2306 656 2475 1025 
+Q 2563 1225 2563 1553 
+L 2563 3406 
+L 3466 3406 
+L 3466 0 
+L 2600 0 
+L 2600 481 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-4f" d="M 434 4606 
+L 1325 4606 
+L 1325 0 
+L 434 0 
+L 434 4606 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-49" d="M 2013 4634 
+L 2013 3909 
+Q 1938 3919 1761 3923 
+Q 1584 3928 1517 3845 
+Q 1450 3763 1450 3663 
+L 1450 3375 
+L 2034 3375 
+L 2034 2747 
+L 1450 2747 
+L 1450 0 
+L 563 0 
+L 563 2747 
+L 66 2747 
+L 66 3375 
+L 553 3375 
+L 553 3594 
+Q 553 4141 738 4347 
+Q 931 4653 1672 4653 
+Q 1756 4653 1825 4648 
+Q 1894 4644 2013 4634 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-4b" d="M 3494 2000 
+L 3494 0 
+L 2584 0 
+L 2584 2072 
+Q 2584 2347 2491 2516 
+Q 2369 2753 2028 2753 
+Q 1675 2753 1492 2517 
+Q 1309 2281 1309 1844 
+L 1309 0 
+L 422 0 
+L 422 4591 
+L 1309 4591 
+L 1309 2963 
+Q 1503 3259 1758 3376 
+Q 2013 3494 2294 3494 
+Q 2609 3494 2867 3384 
+Q 3125 3275 3291 3050 
+Q 3431 2859 3462 2657 
+Q 3494 2456 3494 2000 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-Bold-55"/>
+     <use xlink:href="#Helvetica-Bold-58" transform="translate(38.921875 0)"/>
+     <use xlink:href="#Helvetica-Bold-4f" transform="translate(100 0)"/>
+     <use xlink:href="#Helvetica-Bold-48" transform="translate(127.78125 0)"/>
+     <use xlink:href="#Helvetica-Bold-3" transform="translate(183.390625 0)"/>
+     <use xlink:href="#Helvetica-Bold-52" transform="translate(211.171875 0)"/>
+     <use xlink:href="#Helvetica-Bold-49" transform="translate(272.25 0)"/>
+     <use xlink:href="#Helvetica-Bold-3" transform="translate(305.546875 0)"/>
+     <use xlink:href="#Helvetica-Bold-57" transform="translate(333.328125 0)"/>
+     <use xlink:href="#Helvetica-Bold-4b" transform="translate(366.625 0)"/>
+     <use xlink:href="#Helvetica-Bold-55" transform="translate(427.703125 0)"/>
+     <use xlink:href="#Helvetica-Bold-48" transform="translate(466.625 0)"/>
+     <use xlink:href="#Helvetica-Bold-48" transform="translate(522.234375 0)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- "…readable, maintainable, and solves real problems" -->
+    <g style="fill: #6b7280" transform="translate(45.3025 96.842557) scale(0.08 -0.08)">
+     <defs>
+      <path id="Helvetica-Oblique-44" d="M 1519 366 
+Q 1816 366 2125 503 
+Q 2641 731 2753 1250 
+L 2847 1703 
+Q 2731 1638 2559 1594 
+Q 2388 1550 2228 1531 
+L 1878 1488 
+Q 1563 1447 1391 1359 
+Q 1100 1213 1031 891 
+Q 978 647 1126 506 
+Q 1275 366 1519 366 
+z
+M 2634 2028 
+Q 2834 2053 2931 2191 
+Q 2984 2266 3013 2406 
+Q 3075 2694 2897 2823 
+Q 2719 2953 2338 2953 
+Q 1897 2953 1663 2716 
+Q 1531 2584 1447 2325 
+L 922 2325 
+Q 1069 2944 1506 3186 
+Q 1944 3428 2453 3428 
+Q 3044 3428 3363 3203 
+Q 3681 2978 3581 2503 
+L 3172 575 
+Q 3153 488 3176 434 
+Q 3200 381 3316 381 
+Q 3353 381 3401 386 
+Q 3450 391 3506 400 
+L 3416 -16 
+Q 3278 -53 3208 -62 
+Q 3138 -72 3019 -72 
+Q 2728 -72 2641 134 
+Q 2594 244 2609 444 
+Q 2388 219 2031 53 
+Q 1675 -113 1288 -113 
+Q 822 -113 586 170 
+Q 350 453 441 878 
+Q 541 1344 886 1600 
+Q 1231 1856 1716 1916 
+L 2634 2028 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-47" d="M 1806 372 
+Q 2197 372 2519 708 
+Q 2841 1044 2975 1672 
+Q 3109 2306 2915 2611 
+Q 2722 2916 2341 2916 
+Q 1916 2916 1583 2591 
+Q 1250 2266 1116 1634 
+Q 1000 1097 1151 734 
+Q 1303 372 1806 372 
+z
+M 2947 3244 
+Q 3078 3150 3219 2916 
+L 3578 4606 
+L 4119 4606 
+L 3141 0 
+L 2634 0 
+L 2731 466 
+Q 2469 156 2170 18 
+Q 1872 -119 1525 -119 
+Q 966 -119 656 351 
+Q 347 822 516 1603 
+Q 669 2334 1156 2870 
+Q 1644 3406 2338 3406 
+Q 2722 3406 2947 3244 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-f" d="M 391 -653 
+Q 616 -616 759 -350 
+Q 834 -209 863 -78 
+Q 869 -56 870 -39 
+Q 872 -22 872 0 
+L 531 0 
+L 675 681 
+L 1344 681 
+L 1209 50 
+Q 1131 -322 920 -603 
+Q 709 -884 328 -950 
+L 391 -653 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-59" d="M 1397 3347 
+L 1713 622 
+L 3225 3347 
+L 3841 3347 
+L 1869 0 
+L 1269 0 
+L 744 3347 
+L 1397 3347 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-Oblique-5"/>
+     <use xlink:href="#Helvetica-Oblique-ab" transform="translate(35.5 0)"/>
+     <use xlink:href="#Helvetica-Oblique-55" transform="translate(135.5 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(168.796875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-44" transform="translate(224.40625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-47" transform="translate(280.015625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-44" transform="translate(335.625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-45" transform="translate(391.234375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4f" transform="translate(446.84375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(469.0625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-f" transform="translate(524.671875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(552.453125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-50" transform="translate(580.234375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-44" transform="translate(663.53125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4c" transform="translate(719.140625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-51" transform="translate(741.359375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(796.96875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-44" transform="translate(824.75 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4c" transform="translate(880.359375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-51" transform="translate(902.578125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-44" transform="translate(958.1875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-45" transform="translate(1013.796875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4f" transform="translate(1069.40625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(1091.625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-f" transform="translate(1147.234375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1175.015625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-44" transform="translate(1202.796875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-51" transform="translate(1258.40625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-47" transform="translate(1314.015625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1369.625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-56" transform="translate(1397.40625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-52" transform="translate(1447.40625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4f" transform="translate(1503.015625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-59" transform="translate(1525.234375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(1575.234375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-56" transform="translate(1630.84375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1680.84375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-55" transform="translate(1708.625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(1741.921875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-44" transform="translate(1797.53125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4f" transform="translate(1853.140625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1875.359375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-53" transform="translate(1903.140625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-55" transform="translate(1958.75 0)"/>
+     <use xlink:href="#Helvetica-Oblique-52" transform="translate(1992.046875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-45" transform="translate(2047.65625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4f" transform="translate(2103.265625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(2125.484375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-50" transform="translate(2181.09375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-56" transform="translate(2264.390625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-5" transform="translate(2314.390625 0)"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- 6.2 -->
+    <g style="fill: #4b5563" transform="translate(410.229539 118.136358) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-19"/>
+     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+     <use xlink:href="#Helvetica-15" transform="translate(83.390625 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- 0 -->
+    <g style="fill: #2563eb" transform="translate(242.815428 130.820201) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-13"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- setup / payoff -->
+    <g style="fill: #111827" transform="translate(174.795156 118.926797) scale(0.09 -0.09)">
+     <defs>
+      <path id="Helvetica-Bold-56" d="M 2763 3250 
+Q 3163 2994 3222 2369 
+L 2331 2369 
+Q 2313 2541 2234 2641 
+Q 2088 2822 1734 2822 
+Q 1444 2822 1320 2731 
+Q 1197 2641 1197 2519 
+Q 1197 2366 1328 2297 
+Q 1459 2225 2256 2050 
+Q 2788 1925 3053 1672 
+Q 3316 1416 3316 1031 
+Q 3316 525 2939 204 
+Q 2563 -116 1775 -116 
+Q 972 -116 589 223 
+Q 206 563 206 1088 
+L 1109 1088 
+Q 1138 850 1231 750 
+Q 1397 572 1844 572 
+Q 2106 572 2261 650 
+Q 2416 728 2416 884 
+Q 2416 1034 2291 1113 
+Q 2166 1191 1363 1381 
+Q 784 1525 547 1741 
+Q 309 1953 309 2353 
+Q 309 2825 679 3164 
+Q 1050 3503 1722 3503 
+Q 2359 3503 2763 3250 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-53" d="M 3269 3041 
+Q 3681 2600 3681 1747 
+Q 3681 847 3276 375 
+Q 2872 -97 2234 -97 
+Q 1828 -97 1559 106 
+Q 1413 219 1272 434 
+L 1272 -1341 
+L 391 -1341 
+L 391 3406 
+L 1244 3406 
+L 1244 2903 
+Q 1388 3125 1550 3253 
+Q 1847 3481 2256 3481 
+Q 2853 3481 3269 3041 
+z
+M 2763 1703 
+Q 2763 2097 2583 2400 
+Q 2403 2703 2000 2703 
+Q 1516 2703 1334 2244 
+Q 1241 2000 1241 1625 
+Q 1241 1031 1556 791 
+Q 1744 650 2000 650 
+Q 2372 650 2567 937 
+Q 2763 1225 2763 1703 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-12" d="M -350 0 
+L 1434 4747 
+L 2175 4747 
+L 384 0 
+L -350 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Bold-5c" d="M 1800 894 
+L 2503 3406 
+L 3450 3406 
+L 2281 56 
+Q 1944 -913 1747 -1145 
+Q 1550 -1378 959 -1378 
+Q 841 -1378 769 -1376 
+Q 697 -1375 553 -1366 
+L 553 -653 
+L 666 -659 
+Q 797 -666 915 -650 
+Q 1034 -634 1116 -578 
+Q 1194 -525 1261 -356 
+Q 1328 -188 1316 -150 
+L 66 3406 
+L 1056 3406 
+L 1800 894 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-Bold-56"/>
+     <use xlink:href="#Helvetica-Bold-48" transform="translate(55.609375 0)"/>
+     <use xlink:href="#Helvetica-Bold-57" transform="translate(111.21875 0)"/>
+     <use xlink:href="#Helvetica-Bold-58" transform="translate(144.515625 0)"/>
+     <use xlink:href="#Helvetica-Bold-53" transform="translate(205.59375 0)"/>
+     <use xlink:href="#Helvetica-Bold-3" transform="translate(266.671875 0)"/>
+     <use xlink:href="#Helvetica-Bold-12" transform="translate(294.453125 0)"/>
+     <use xlink:href="#Helvetica-Bold-3" transform="translate(322.234375 0)"/>
+     <use xlink:href="#Helvetica-Bold-53" transform="translate(350.015625 0)"/>
+     <use xlink:href="#Helvetica-Bold-44" transform="translate(411.09375 0)"/>
+     <use xlink:href="#Helvetica-Bold-5c" transform="translate(466.703125 0)"/>
+     <use xlink:href="#Helvetica-Bold-52" transform="translate(522.3125 0)"/>
+     <use xlink:href="#Helvetica-Bold-49" transform="translate(583.390625 0)"/>
+     <use xlink:href="#Helvetica-Bold-49" transform="translate(616.6875 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- "But three weeks later? They hit a tricky bug…" -->
+    <g style="fill: #6b7280" transform="translate(66.3575 132.024205) scale(0.08 -0.08)">
+     <defs>
+      <path id="Helvetica-Oblique-25" d="M 2775 2650 
+Q 3169 2650 3409 2759 
+Q 3791 2931 3884 3378 
+Q 3981 3828 3650 3984 
+Q 3459 4072 3053 4072 
+L 1944 4072 
+L 1644 2650 
+L 2775 2650 
+z
+M 2534 531 
+Q 3106 531 3419 863 
+Q 3616 1072 3681 1369 
+Q 3788 1869 3378 2050 
+Q 3163 2147 2772 2147 
+L 1538 2147 
+L 1194 531 
+L 2534 531 
+z
+M 1447 4591 
+L 3419 4591 
+Q 4225 4591 4463 4109 
+Q 4603 3825 4522 3453 
+Q 4431 3019 4125 2741 
+Q 3966 2594 3700 2472 
+Q 4022 2338 4163 2169 
+Q 4409 1869 4297 1341 
+Q 4203 897 3847 538 
+Q 3319 0 2413 0 
+L 472 0 
+L 1447 4591 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-58" d="M 1684 3347 
+L 1213 1125 
+Q 1159 869 1206 706 
+Q 1291 406 1700 406 
+Q 2288 406 2613 931 
+Q 2788 1213 2891 1703 
+L 3241 3347 
+L 3803 3347 
+L 3094 0 
+L 2563 0 
+L 2672 494 
+Q 2522 303 2331 172 
+Q 1953 -91 1494 -91 
+Q 778 -91 622 388 
+Q 534 644 625 1072 
+L 1109 3347 
+L 1684 3347 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-5a" d="M 1381 3347 
+L 1466 709 
+L 2678 3347 
+L 3309 3347 
+L 3409 725 
+L 4650 3347 
+L 5213 3347 
+L 3531 0 
+L 2947 0 
+L 2816 2591 
+L 1606 0 
+L 1022 0 
+L 766 3347 
+L 1381 3347 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-22" d="M 1678 650 
+L 2300 650 
+L 2163 0 
+L 1541 0 
+L 1678 650 
+z
+M 2903 4650 
+Q 3519 4650 3814 4298 
+Q 4109 3947 3994 3400 
+Q 3922 3069 3742 2862 
+Q 3563 2656 3066 2256 
+Q 2703 1966 2572 1764 
+Q 2441 1563 2356 1169 
+L 1800 1169 
+Q 1894 1616 2059 1889 
+Q 2225 2163 2659 2516 
+L 2959 2763 
+Q 3097 2869 3188 2984 
+Q 3356 3188 3403 3406 
+Q 3469 3713 3334 3938 
+Q 3200 4163 2778 4163 
+Q 2256 4163 1972 3775 
+Q 1816 3559 1713 3153 
+L 1156 3153 
+Q 1300 3828 1769 4239 
+Q 2238 4650 2903 4650 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-5c" d="M 3213 3347 
+L 3834 3347 
+Q 3647 3025 2994 1878 
+Q 2506 1016 2184 472 
+Q 1422 -809 1162 -1090 
+Q 903 -1372 416 -1372 
+Q 297 -1372 234 -1362 
+Q 172 -1353 84 -1328 
+L 194 -816 
+Q 331 -856 395 -865 
+Q 459 -875 509 -875 
+Q 666 -875 750 -823 
+Q 834 -772 900 -697 
+Q 922 -672 1067 -440 
+Q 1213 -209 1281 -97 
+L 775 3347 
+L 1413 3347 
+L 1731 622 
+L 3213 3347 
+z
+" transform="scale(0.015625)"/>
+      <path id="Helvetica-Oblique-46" d="M 3522 2222 
+L 2975 2222 
+Q 2991 2531 2856 2736 
+Q 2722 2941 2328 2941 
+Q 1791 2941 1447 2416 
+Q 1225 2075 1119 1575 
+Q 1009 1072 1150 728 
+Q 1291 384 1747 384 
+Q 2097 384 2347 598 
+Q 2597 813 2753 1184 
+L 3300 1184 
+Q 3066 519 2625 211 
+Q 2184 -97 1600 -97 
+Q 944 -97 655 383 
+Q 366 863 519 1581 
+Q 706 2463 1239 2953 
+Q 1772 3444 2434 3444 
+Q 3000 3444 3295 3169 
+Q 3591 2894 3522 2222 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-Oblique-5"/>
+     <use xlink:href="#Helvetica-Oblique-25" transform="translate(35.5 0)"/>
+     <use xlink:href="#Helvetica-Oblique-58" transform="translate(102.203125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(157.8125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(185.59375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(213.375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4b" transform="translate(241.15625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-55" transform="translate(296.765625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(330.0625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(385.671875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(441.28125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-5a" transform="translate(469.0625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(541.28125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(596.890625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4e" transform="translate(652.5 0)"/>
+     <use xlink:href="#Helvetica-Oblique-56" transform="translate(702.5 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(752.5 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4f" transform="translate(780.28125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-44" transform="translate(802.5 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(858.109375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(885.890625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-55" transform="translate(941.5 0)"/>
+     <use xlink:href="#Helvetica-Oblique-22" transform="translate(974.796875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1030.40625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-37" transform="translate(1056.4375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4b" transform="translate(1117.515625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(1173.125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-5c" transform="translate(1228.734375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1278.734375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4b" transform="translate(1306.515625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4c" transform="translate(1362.125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(1384.34375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1412.125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-44" transform="translate(1439.90625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1495.515625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(1523.296875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-55" transform="translate(1551.078125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4c" transform="translate(1584.375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-46" transform="translate(1606.59375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4e" transform="translate(1656.59375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-5c" transform="translate(1706.59375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1756.59375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-45" transform="translate(1784.375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-58" transform="translate(1839.984375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4a" transform="translate(1895.59375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-ab" transform="translate(1951.203125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-5" transform="translate(2051.203125 0)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 4.6 -->
+    <g style="fill: #4b5563" transform="translate(368.376011 153.369255) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-17"/>
+     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+     <use xlink:href="#Helvetica-19" transform="translate(83.390625 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 0 -->
+    <g style="fill: #2563eb" transform="translate(242.815428 166.053098) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-13"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- landing sentence -->
+    <g style="fill: #111827" transform="translate(159.784844 154.148445) scale(0.09 -0.09)">
+     <defs>
+      <path id="Helvetica-Bold-47" d="M 3516 4600 
+L 3516 0 
+L 2650 0 
+L 2650 472 
+Q 2459 169 2215 31 
+Q 1972 -106 1609 -106 
+Q 1013 -106 605 376 
+Q 197 859 197 1616 
+Q 197 2488 598 2988 
+Q 1000 3488 1672 3488 
+Q 1981 3488 2222 3352 
+Q 2463 3216 2613 2975 
+L 2613 4600 
+L 3516 4600 
+z
+M 1116 1681 
+Q 1116 1209 1303 928 
+Q 1488 644 1866 644 
+Q 2244 644 2441 925 
+Q 2638 1206 2638 1653 
+Q 2638 2278 2322 2547 
+Q 2128 2709 1872 2709 
+Q 1481 2709 1298 2414 
+Q 1116 2119 1116 1681 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-Bold-4f"/>
+     <use xlink:href="#Helvetica-Bold-44" transform="translate(27.78125 0)"/>
+     <use xlink:href="#Helvetica-Bold-51" transform="translate(83.390625 0)"/>
+     <use xlink:href="#Helvetica-Bold-47" transform="translate(144.46875 0)"/>
+     <use xlink:href="#Helvetica-Bold-4c" transform="translate(205.546875 0)"/>
+     <use xlink:href="#Helvetica-Bold-51" transform="translate(233.328125 0)"/>
+     <use xlink:href="#Helvetica-Bold-4a" transform="translate(294.40625 0)"/>
+     <use xlink:href="#Helvetica-Bold-3" transform="translate(355.484375 0)"/>
+     <use xlink:href="#Helvetica-Bold-56" transform="translate(383.265625 0)"/>
+     <use xlink:href="#Helvetica-Bold-48" transform="translate(438.875 0)"/>
+     <use xlink:href="#Helvetica-Bold-51" transform="translate(494.484375 0)"/>
+     <use xlink:href="#Helvetica-Bold-57" transform="translate(555.5625 0)"/>
+     <use xlink:href="#Helvetica-Bold-48" transform="translate(588.859375 0)"/>
+     <use xlink:href="#Helvetica-Bold-51" transform="translate(644.46875 0)"/>
+     <use xlink:href="#Helvetica-Bold-46" transform="translate(705.546875 0)"/>
+     <use xlink:href="#Helvetica-Bold-48" transform="translate(761.15625 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- "The difference is huge." -->
+    <g style="fill: #6b7280" transform="translate(146.3775 167.257102) scale(0.08 -0.08)">
+     <defs>
+      <path id="Helvetica-Oblique-49" d="M 1603 4369 
+Q 1859 4656 2422 4656 
+Q 2475 4656 2531 4653 
+Q 2588 4650 2656 4644 
+L 2547 4131 
+Q 2463 4138 2423 4139 
+Q 2384 4141 2350 4141 
+Q 2094 4141 2016 4008 
+Q 1938 3875 1822 3331 
+L 2378 3331 
+L 2284 2888 
+L 1722 2888 
+L 1109 0 
+L 553 0 
+L 1166 2888 
+L 700 2888 
+L 794 3331 
+L 1259 3331 
+L 1372 3856 
+Q 1459 4206 1603 4369 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-Oblique-5"/>
+     <use xlink:href="#Helvetica-Oblique-37" transform="translate(35.5 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4b" transform="translate(96.578125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(152.1875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(207.796875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-47" transform="translate(235.578125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4c" transform="translate(291.1875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-49" transform="translate(313.40625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-49" transform="translate(339.4375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(367.21875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-55" transform="translate(422.828125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(456.125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-51" transform="translate(511.734375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-46" transform="translate(567.34375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(617.34375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(672.953125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4c" transform="translate(700.734375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-56" transform="translate(722.953125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(772.953125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4b" transform="translate(800.734375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-58" transform="translate(856.34375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4a" transform="translate(911.953125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(967.5625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-11" transform="translate(1023.171875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-5" transform="translate(1050.953125 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 4.6 -->
+    <g style="fill: #4b5563" transform="translate(368.376011 188.602153) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-17"/>
+     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+     <use xlink:href="#Helvetica-19" transform="translate(83.390625 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 2.3 -->
+    <g style="fill: #2563eb" transform="translate(306.082388 201.285996) scale(0.08 -0.08)">
+     <defs>
+      <path id="Helvetica-16" d="M 1663 -122 
+Q 869 -122 511 314 
+Q 153 750 153 1375 
+L 741 1375 
+Q 778 941 903 744 
+Q 1122 391 1694 391 
+Q 2138 391 2406 628 
+Q 2675 866 2675 1241 
+Q 2675 1703 2392 1887 
+Q 2109 2072 1606 2072 
+Q 1550 2072 1492 2070 
+Q 1434 2069 1375 2066 
+L 1375 2563 
+Q 1463 2553 1522 2550 
+Q 1581 2547 1650 2547 
+Q 1966 2547 2169 2647 
+Q 2525 2822 2525 3272 
+Q 2525 3606 2287 3787 
+Q 2050 3969 1734 3969 
+Q 1172 3969 956 3594 
+Q 838 3388 822 3006 
+L 266 3006 
+Q 266 3506 466 3856 
+Q 809 4481 1675 4481 
+Q 2359 4481 2734 4176 
+Q 3109 3872 3109 3294 
+Q 3109 2881 2888 2625 
+Q 2750 2466 2531 2375 
+Q 2884 2278 3082 2001 
+Q 3281 1725 3281 1325 
+Q 3281 684 2859 281 
+Q 2438 -122 1663 -122 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Helvetica-15"/>
+     <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+     <use xlink:href="#Helvetica-16" transform="translate(83.390625 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- contrast / anaphora -->
+    <g style="fill: #111827" transform="translate(149.782187 189.418608) scale(0.09 -0.09)">
+     <use xlink:href="#Helvetica-Bold-46"/>
+     <use xlink:href="#Helvetica-Bold-52" transform="translate(55.609375 0)"/>
+     <use xlink:href="#Helvetica-Bold-51" transform="translate(116.6875 0)"/>
+     <use xlink:href="#Helvetica-Bold-57" transform="translate(177.765625 0)"/>
+     <use xlink:href="#Helvetica-Bold-55" transform="translate(211.0625 0)"/>
+     <use xlink:href="#Helvetica-Bold-44" transform="translate(249.984375 0)"/>
+     <use xlink:href="#Helvetica-Bold-56" transform="translate(305.59375 0)"/>
+     <use xlink:href="#Helvetica-Bold-57" transform="translate(361.203125 0)"/>
+     <use xlink:href="#Helvetica-Bold-3" transform="translate(394.5 0)"/>
+     <use xlink:href="#Helvetica-Bold-12" transform="translate(422.28125 0)"/>
+     <use xlink:href="#Helvetica-Bold-3" transform="translate(450.0625 0)"/>
+     <use xlink:href="#Helvetica-Bold-44" transform="translate(477.84375 0)"/>
+     <use xlink:href="#Helvetica-Bold-51" transform="translate(533.453125 0)"/>
+     <use xlink:href="#Helvetica-Bold-44" transform="translate(594.53125 0)"/>
+     <use xlink:href="#Helvetica-Bold-53" transform="translate(650.140625 0)"/>
+     <use xlink:href="#Helvetica-Bold-4b" transform="translate(711.21875 0)"/>
+     <use xlink:href="#Helvetica-Bold-52" transform="translate(772.296875 0)"/>
+     <use xlink:href="#Helvetica-Bold-55" transform="translate(833.375 0)"/>
+     <use xlink:href="#Helvetica-Bold-44" transform="translate(872.296875 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- "…pretty good at the happy path. It’s terrible at everything else." -->
+    <g style="fill: #6b7280" transform="translate(7.2 202.489999) scale(0.08 -0.08)">
+     <use xlink:href="#Helvetica-Oblique-5"/>
+     <use xlink:href="#Helvetica-Oblique-ab" transform="translate(35.5 0)"/>
+     <use xlink:href="#Helvetica-Oblique-53" transform="translate(135.5 0)"/>
+     <use xlink:href="#Helvetica-Oblique-55" transform="translate(191.109375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(224.40625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(280.015625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(307.796875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-5c" transform="translate(335.578125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(385.578125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4a" transform="translate(413.359375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-52" transform="translate(468.96875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-52" transform="translate(524.578125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-47" transform="translate(580.1875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(635.796875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-44" transform="translate(663.578125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(719.1875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(746.96875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(774.75 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4b" transform="translate(802.53125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(858.140625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(913.75 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4b" transform="translate(941.53125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-44" transform="translate(997.140625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-53" transform="translate(1052.75 0)"/>
+     <use xlink:href="#Helvetica-Oblique-53" transform="translate(1108.359375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-5c" transform="translate(1163.96875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1213.96875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-53" transform="translate(1241.75 0)"/>
+     <use xlink:href="#Helvetica-Oblique-44" transform="translate(1297.359375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(1352.96875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4b" transform="translate(1380.75 0)"/>
+     <use xlink:href="#Helvetica-Oblique-11" transform="translate(1436.359375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1464.140625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-2c" transform="translate(1491.921875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(1519.703125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-b7" transform="translate(1547.484375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-56" transform="translate(1567.953125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1617.953125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(1645.734375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(1673.515625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-55" transform="translate(1729.125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-55" transform="translate(1762.421875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4c" transform="translate(1795.71875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-45" transform="translate(1817.9375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4f" transform="translate(1873.546875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(1895.765625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(1951.375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-44" transform="translate(1979.15625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(2034.765625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(2062.546875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(2090.328125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-59" transform="translate(2145.9375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(2195.9375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-55" transform="translate(2251.546875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-5c" transform="translate(2284.84375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-57" transform="translate(2334.84375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4b" transform="translate(2362.625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4c" transform="translate(2418.234375 0)"/>
+     <use xlink:href="#Helvetica-Oblique-51" transform="translate(2440.453125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4a" transform="translate(2496.0625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-3" transform="translate(2551.671875 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(2579.453125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-4f" transform="translate(2635.0625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-56" transform="translate(2657.28125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-48" transform="translate(2707.28125 0)"/>
+     <use xlink:href="#Helvetica-Oblique-11" transform="translate(2762.890625 0)"/>
+     <use xlink:href="#Helvetica-Oblique-5" transform="translate(2790.671875 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- (a) -->
+    <g transform="translate(99.709845 17.72766) scale(0.1 -0.1)">
+     <defs>
+      <path id="Helvetica-Bold-b" d="M 1394 -1291 
+L 1172 -988 
+Q 956 -713 713 -169 
+Q 278 803 278 1744 
+Q 278 2600 644 3444 
+Q 891 4019 1366 4681 
+L 2038 4681 
+L 1847 4331 
+Q 1453 3609 1300 2819 
+Q 1200 2300 1200 1688 
+Q 1200 731 1478 -72 
+Q 1641 -547 2053 -1291 
+L 1394 -1291 
+z
+" transform="scale(0.015625)"/>
       <path id="Helvetica-Bold-c" d="M 947 -988 
 L 725 -1291 
 L 66 -1291 
@@ -1321,17 +2259,17 @@ z
     </g>
    </g>
    <g id="legend_1">
-    <g id="patch_15">
-     <path d="M 140.106779 33.22224 
-L 156.106779 33.22224 
-L 156.106779 27.62224 
-L 140.106779 27.62224 
+    <g id="patch_16">
+     <path d="M 251.8235 16.4 
+L 263.0235 16.4 
+L 263.0235 10.8 
+L 251.8235 10.8 
 z
 " style="fill: #4b5563"/>
     </g>
-    <g id="text_27">
+    <g id="text_28">
      <!-- AI-assisted post (n=130 sentences) -->
-     <g transform="translate(162.506779 33.22224) scale(0.08 -0.08)">
+     <g transform="translate(269.4235 16.4) scale(0.08 -0.08)">
       <defs>
        <path id="Helvetica-24" d="M 2844 1881 
 L 2147 3909 
@@ -1361,6 +2299,76 @@ L 1834 2072
 L 1834 1494 
 L 266 1494 
 L 266 2072 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-44" d="M 844 891 
+Q 844 647 1022 506 
+Q 1200 366 1444 366 
+Q 1741 366 2019 503 
+Q 2488 731 2488 1250 
+L 2488 1703 
+Q 2384 1638 2221 1594 
+Q 2059 1550 1903 1531 
+L 1563 1488 
+Q 1256 1447 1103 1359 
+Q 844 1213 844 891 
+z
+M 2206 2028 
+Q 2400 2053 2466 2191 
+Q 2503 2266 2503 2406 
+Q 2503 2694 2298 2823 
+Q 2094 2953 1713 2953 
+Q 1272 2953 1088 2716 
+Q 984 2584 953 2325 
+L 428 2325 
+Q 444 2944 830 3186 
+Q 1216 3428 1725 3428 
+Q 2316 3428 2684 3203 
+Q 3050 2978 3050 2503 
+L 3050 575 
+Q 3050 488 3086 434 
+Q 3122 381 3238 381 
+Q 3275 381 3322 386 
+Q 3369 391 3422 400 
+L 3422 -16 
+Q 3291 -53 3222 -62 
+Q 3153 -72 3034 -72 
+Q 2744 -72 2613 134 
+Q 2544 244 2516 444 
+Q 2344 219 2022 53 
+Q 1700 -113 1313 -113 
+Q 847 -113 551 170 
+Q 256 453 256 878 
+Q 256 1344 547 1600 
+Q 838 1856 1309 1916 
+L 2206 2028 
+z
+M 1741 3428 
+L 1741 3428 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-52" d="M 1741 363 
+Q 2300 363 2508 786 
+Q 2716 1209 2716 1728 
+Q 2716 2197 2566 2491 
+Q 2328 2953 1747 2953 
+Q 1231 2953 997 2559 
+Q 763 2166 763 1609 
+Q 763 1075 997 719 
+Q 1231 363 1741 363 
+z
+M 1763 3444 
+Q 2409 3444 2856 3012 
+Q 3303 2581 3303 1744 
+Q 3303 934 2909 406 
+Q 2516 -122 1688 -122 
+Q 997 -122 590 345 
+Q 184 813 184 1600 
+Q 184 2444 612 2944 
+Q 1041 3444 1763 3444 
+z
+M 1744 3428 
+L 1744 3428 
 z
 " transform="scale(0.015625)"/>
        <path id="Helvetica-b" d="M 1894 4666 
@@ -1443,17 +2451,38 @@ z
       <use xlink:href="#Helvetica-c" transform="translate(1536.921875 0)"/>
      </g>
     </g>
-    <g id="patch_16">
-     <path d="M 140.106779 44.88974 
-L 156.106779 44.88974 
-L 156.106779 39.28974 
-L 140.106779 39.28974 
+    <g id="patch_17">
+     <path d="M 404.641 16.4 
+L 415.841 16.4 
+L 415.841 10.8 
+L 404.641 10.8 
 z
 " style="fill: #2563eb"/>
     </g>
-    <g id="text_28">
-     <!-- this post (n=39) -->
-     <g transform="translate(162.506779 44.88974) scale(0.08 -0.08)">
+    <g id="text_29">
+     <!-- this post (n=43) -->
+     <g transform="translate(422.241 16.4) scale(0.08 -0.08)">
+      <defs>
+       <path id="Helvetica-4b" d="M 413 4606 
+L 975 4606 
+L 975 2894 
+Q 1175 3147 1334 3250 
+Q 1606 3428 2013 3428 
+Q 2741 3428 3000 2919 
+Q 3141 2641 3141 2147 
+L 3141 0 
+L 2563 0 
+L 2563 2109 
+Q 2563 2478 2469 2650 
+Q 2316 2925 1894 2925 
+Q 1544 2925 1259 2684 
+Q 975 2444 975 1775 
+L 975 0 
+L 413 0 
+L 413 4606 
+z
+" transform="scale(0.015625)"/>
+      </defs>
       <use xlink:href="#Helvetica-57"/>
       <use xlink:href="#Helvetica-4b" transform="translate(27.78125 0)"/>
       <use xlink:href="#Helvetica-4c" transform="translate(83.390625 0)"/>
@@ -1467,223 +2496,195 @@ z
       <use xlink:href="#Helvetica-b" transform="translate(400.171875 0)"/>
       <use xlink:href="#Helvetica-51" transform="translate(433.46875 0)"/>
       <use xlink:href="#Helvetica-20" transform="translate(489.078125 0)"/>
-      <use xlink:href="#Helvetica-16" transform="translate(547.484375 0)"/>
-      <use xlink:href="#Helvetica-1c" transform="translate(603.09375 0)"/>
+      <use xlink:href="#Helvetica-17" transform="translate(547.484375 0)"/>
+      <use xlink:href="#Helvetica-16" transform="translate(603.09375 0)"/>
       <use xlink:href="#Helvetica-c" transform="translate(658.703125 0)"/>
      </g>
     </g>
    </g>
   </g>
   <g id="axes_2">
-   <g id="patch_17">
-    <path d="M 357.917322 197.43024 
-L 512.468047 197.43024 
-L 512.468047 20.02224 
-L 357.917322 20.02224 
+   <g id="patch_18">
+    <path d="M 507.994534 213.7635 
+L 627.166948 213.7635 
+L 627.166948 25.2675 
+L 507.994534 25.2675 
 z
 " style="fill: #ffffff"/>
    </g>
-   <g id="patch_18">
-    <path d="M 364.942355 197.43024 
-L 364.942355 178.656907 
-L 374.309066 178.656907 
-L 374.309066 84.79024 
-L 383.675776 84.79024 
-L 383.675776 28.47024 
-L 393.042487 28.47024 
-L 393.042487 84.79024 
-L 402.409198 84.79024 
-L 402.409198 66.016907 
-L 411.775908 66.016907 
-L 411.775908 91.048018 
-L 421.142619 91.048018 
-L 421.142619 141.11024 
-L 430.509329 141.11024 
-L 430.509329 147.368018 
-L 439.87604 147.368018 
-L 439.87604 178.656907 
-L 449.24275 178.656907 
-L 449.24275 184.914684 
-L 458.609461 184.914684 
-L 458.609461 184.914684 
-L 467.976172 184.914684 
-L 467.976172 197.43024 
-L 477.342882 197.43024 
-L 477.342882 191.172462 
-L 486.709593 191.172462 
-L 486.709593 197.43024 
-L 496.076303 197.43024 
-L 496.076303 191.172462 
-L 505.443014 191.172462 
-L 505.443014 197.43024 
-L 496.076303 197.43024 
-L 496.076303 197.43024 
-L 486.709593 197.43024 
-L 486.709593 197.43024 
-L 477.342882 197.43024 
-L 477.342882 197.43024 
-L 467.976172 197.43024 
-L 467.976172 197.43024 
-L 458.609461 197.43024 
-L 458.609461 197.43024 
-L 449.24275 197.43024 
-L 449.24275 197.43024 
-L 439.87604 197.43024 
-L 439.87604 197.43024 
-L 430.509329 197.43024 
-L 430.509329 197.43024 
-L 421.142619 197.43024 
-L 421.142619 197.43024 
-L 411.775908 197.43024 
-L 411.775908 197.43024 
-L 402.409198 197.43024 
-L 402.409198 197.43024 
-L 393.042487 197.43024 
-L 393.042487 197.43024 
-L 383.675776 197.43024 
-L 383.675776 197.43024 
-L 374.309066 197.43024 
-L 374.309066 197.43024 
-z
-" clip-path="url(#p09216fdf78)" style="fill: #9ca3af; opacity: 0.85"/>
-   </g>
    <g id="patch_19">
-    <path d="M 364.942355 197.43024 
-L 364.942355 134.852462 
-L 374.309066 134.852462 
-L 374.309066 72.274684 
-L 383.675776 72.274684 
-L 383.675776 93.133944 
-L 393.042487 93.133944 
-L 393.042487 30.556166 
-L 402.409198 30.556166 
-L 402.409198 155.711721 
-L 411.775908 155.711721 
-L 411.775908 113.993203 
-L 421.142619 113.993203 
-L 421.142619 155.711721 
-L 430.509329 155.711721 
-L 430.509329 113.993203 
-L 439.87604 113.993203 
-L 439.87604 134.852462 
-L 449.24275 134.852462 
-L 449.24275 197.43024 
-L 458.609461 197.43024 
-L 458.609461 176.570981 
-L 467.976172 176.570981 
-L 467.976172 197.43024 
-L 477.342882 197.43024 
-L 477.342882 176.570981 
-L 486.709593 176.570981 
-L 486.709593 197.43024 
-L 496.076303 197.43024 
-L 496.076303 197.43024 
-L 505.443014 197.43024 
-L 505.443014 197.43024 
-L 496.076303 197.43024 
-L 496.076303 197.43024 
-L 486.709593 197.43024 
-L 486.709593 197.43024 
-L 477.342882 197.43024 
-L 477.342882 197.43024 
-L 467.976172 197.43024 
-L 467.976172 197.43024 
-L 458.609461 197.43024 
-L 458.609461 197.43024 
-L 449.24275 197.43024 
-L 449.24275 197.43024 
-L 439.87604 197.43024 
-L 439.87604 197.43024 
-L 430.509329 197.43024 
-L 430.509329 197.43024 
-L 421.142619 197.43024 
-L 421.142619 197.43024 
-L 411.775908 197.43024 
-L 411.775908 197.43024 
-L 402.409198 197.43024 
-L 402.409198 197.43024 
-L 393.042487 197.43024 
-L 393.042487 197.43024 
-L 383.675776 197.43024 
-L 383.675776 197.43024 
-L 374.309066 197.43024 
-L 374.309066 197.43024 
+    <path d="M 513.411462 213.7635 
+L 513.411462 193.816833 
+L 520.634033 193.816833 
+L 520.634033 94.0835 
+L 527.856603 94.0835 
+L 527.856603 34.2435 
+L 535.079174 34.2435 
+L 535.079174 94.0835 
+L 542.301745 94.0835 
+L 542.301745 74.136833 
+L 549.524315 74.136833 
+L 549.524315 100.732389 
+L 556.746886 100.732389 
+L 556.746886 153.9235 
+L 563.969456 153.9235 
+L 563.969456 160.572389 
+L 571.192027 160.572389 
+L 571.192027 193.816833 
+L 578.414597 193.816833 
+L 578.414597 200.465722 
+L 585.637168 200.465722 
+L 585.637168 200.465722 
+L 592.859738 200.465722 
+L 592.859738 213.7635 
+L 600.082309 213.7635 
+L 600.082309 207.114611 
+L 607.304879 207.114611 
+L 607.304879 213.7635 
+L 614.52745 213.7635 
+L 614.52745 207.114611 
+L 621.75002 207.114611 
+L 621.75002 213.7635 
+L 614.52745 213.7635 
+L 614.52745 213.7635 
+L 607.304879 213.7635 
+L 607.304879 213.7635 
+L 600.082309 213.7635 
+L 600.082309 213.7635 
+L 592.859738 213.7635 
+L 592.859738 213.7635 
+L 585.637168 213.7635 
+L 585.637168 213.7635 
+L 578.414597 213.7635 
+L 578.414597 213.7635 
+L 571.192027 213.7635 
+L 571.192027 213.7635 
+L 563.969456 213.7635 
+L 563.969456 213.7635 
+L 556.746886 213.7635 
+L 556.746886 213.7635 
+L 549.524315 213.7635 
+L 549.524315 213.7635 
+L 542.301745 213.7635 
+L 542.301745 213.7635 
+L 535.079174 213.7635 
+L 535.079174 213.7635 
+L 527.856603 213.7635 
+L 527.856603 213.7635 
+L 520.634033 213.7635 
+L 520.634033 213.7635 
 z
-" clip-path="url(#p09216fdf78)" style="fill: #2563eb; opacity: 0.4; stroke: #2563eb; stroke-linejoin: miter"/>
+" clip-path="url(#p32c208dbd8)" style="fill: #9ca3af; opacity: 0.85"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 513.411462 213.7635 
+L 513.411462 153.459624 
+L 520.634033 153.459624 
+L 520.634033 73.054456 
+L 527.856603 73.054456 
+L 527.856603 93.155748 
+L 535.079174 93.155748 
+L 535.079174 52.953164 
+L 542.301745 52.953164 
+L 542.301745 173.560916 
+L 549.524315 173.560916 
+L 549.524315 133.358332 
+L 556.746886 133.358332 
+L 556.746886 153.459624 
+L 563.969456 153.459624 
+L 563.969456 113.25704 
+L 571.192027 113.25704 
+L 571.192027 153.459624 
+L 578.414597 153.459624 
+L 578.414597 213.7635 
+L 585.637168 213.7635 
+L 585.637168 193.662208 
+L 592.859738 193.662208 
+L 592.859738 213.7635 
+L 600.082309 213.7635 
+L 600.082309 193.662208 
+L 607.304879 193.662208 
+L 607.304879 213.7635 
+L 614.52745 213.7635 
+L 614.52745 213.7635 
+L 621.75002 213.7635 
+L 621.75002 213.7635 
+L 614.52745 213.7635 
+L 614.52745 213.7635 
+L 607.304879 213.7635 
+L 607.304879 213.7635 
+L 600.082309 213.7635 
+L 600.082309 213.7635 
+L 592.859738 213.7635 
+L 592.859738 213.7635 
+L 585.637168 213.7635 
+L 585.637168 213.7635 
+L 578.414597 213.7635 
+L 578.414597 213.7635 
+L 571.192027 213.7635 
+L 571.192027 213.7635 
+L 563.969456 213.7635 
+L 563.969456 213.7635 
+L 556.746886 213.7635 
+L 556.746886 213.7635 
+L 549.524315 213.7635 
+L 549.524315 213.7635 
+L 542.301745 213.7635 
+L 542.301745 213.7635 
+L 535.079174 213.7635 
+L 535.079174 213.7635 
+L 527.856603 213.7635 
+L 527.856603 213.7635 
+L 520.634033 213.7635 
+L 520.634033 213.7635 
+z
+" clip-path="url(#p32c208dbd8)" style="fill: #2563eb; opacity: 0.4; stroke: #2563eb; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_6">
-     <g id="line2d_15">
+     <g id="line2d_6">
       <g>
-       <use xlink:href="#m8ca0a002df" x="364.942355" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb9895ed98" x="513.411462" y="213.7635" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_29">
+     <g id="text_30">
       <!-- 0 -->
-      <g transform="translate(362.30091 211.55524) scale(0.095 -0.095)">
+      <g transform="translate(510.770017 227.8885) scale(0.095 -0.095)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
-     <g id="line2d_16">
+     <g id="line2d_7">
       <g>
-       <use xlink:href="#m8ca0a002df" x="396.164724" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_30">
-      <!-- 10 -->
-      <g transform="translate(390.881833 211.55524) scale(0.095 -0.095)">
-       <use xlink:href="#Helvetica-14"/>
-       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_8">
-     <g id="line2d_17">
-      <g>
-       <use xlink:href="#m8ca0a002df" x="427.387092" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb9895ed98" x="561.561933" y="213.7635" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_31">
       <!-- 20 -->
-      <g transform="translate(422.104202 211.55524) scale(0.095 -0.095)">
+      <g transform="translate(556.279042 227.8885) scale(0.095 -0.095)">
        <use xlink:href="#Helvetica-15"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
      </g>
     </g>
-    <g id="xtick_9">
-     <g id="line2d_18">
+    <g id="xtick_8">
+     <g id="line2d_8">
       <g>
-       <use xlink:href="#m8ca0a002df" x="458.609461" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb9895ed98" x="609.712403" y="213.7635" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_32">
-      <!-- 30 -->
-      <g transform="translate(453.32657 211.55524) scale(0.095 -0.095)">
-       <use xlink:href="#Helvetica-16"/>
-       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_10">
-     <g id="line2d_19">
-      <g>
-       <use xlink:href="#m8ca0a002df" x="489.83183" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_33">
       <!-- 40 -->
-      <g transform="translate(484.548939 211.55524) scale(0.095 -0.095)">
+      <g transform="translate(604.429512 227.8885) scale(0.095 -0.095)">
        <use xlink:href="#Helvetica-17"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
      </g>
     </g>
-    <g id="text_34">
+    <g id="text_33">
      <!-- words per sentence -->
-     <g transform="translate(393.742255 224.294498) scale(0.095 -0.095)">
+     <g transform="translate(526.130312 240.627758) scale(0.095 -0.095)">
       <defs>
        <path id="Helvetica-5a" d="M 672 3347 
 L 1316 709 
@@ -1724,15 +2725,20 @@ z
     </g>
    </g>
    <g id="matplotlib.axis_4">
-    <g id="ytick_10">
-     <g id="line2d_20">
+    <g id="ytick_1">
+     <g id="line2d_9">
+      <defs>
+       <path id="me0dcc62529" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
       <g>
-       <use xlink:href="#me15a2e6f0d" x="357.917322" y="197.43024" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me0dcc62529" x="507.994534" y="213.7635" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_35">
+     <g id="text_34">
       <!-- 0.00 -->
-      <g transform="translate(332.429432 200.99274) scale(0.095 -0.095)">
+      <g transform="translate(482.506644 217.326) scale(0.095 -0.095)">
        <use xlink:href="#Helvetica-13"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -1740,15 +2746,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_11">
-     <g id="line2d_21">
+    <g id="ytick_2">
+     <g id="line2d_10">
       <g>
-       <use xlink:href="#me15a2e6f0d" x="357.917322" y="173.024907" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me0dcc62529" x="507.994534" y="187.832833" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_36">
+     <g id="text_35">
       <!-- 0.01 -->
-      <g transform="translate(332.429432 176.587407) scale(0.095 -0.095)">
+      <g transform="translate(482.506644 191.395333) scale(0.095 -0.095)">
        <use xlink:href="#Helvetica-13"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -1756,15 +2762,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_12">
-     <g id="line2d_22">
+    <g id="ytick_3">
+     <g id="line2d_11">
       <g>
-       <use xlink:href="#me15a2e6f0d" x="357.917322" y="148.619573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me0dcc62529" x="507.994534" y="161.902167" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_37">
+     <g id="text_36">
       <!-- 0.02 -->
-      <g transform="translate(332.429432 152.182073) scale(0.095 -0.095)">
+      <g transform="translate(482.506644 165.464667) scale(0.095 -0.095)">
        <use xlink:href="#Helvetica-13"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -1772,15 +2778,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_13">
-     <g id="line2d_23">
+    <g id="ytick_4">
+     <g id="line2d_12">
       <g>
-       <use xlink:href="#me15a2e6f0d" x="357.917322" y="124.21424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me0dcc62529" x="507.994534" y="135.9715" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_38">
+     <g id="text_37">
       <!-- 0.03 -->
-      <g transform="translate(332.429432 127.77674) scale(0.095 -0.095)">
+      <g transform="translate(482.506644 139.534) scale(0.095 -0.095)">
        <use xlink:href="#Helvetica-13"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -1788,15 +2794,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_14">
-     <g id="line2d_24">
+    <g id="ytick_5">
+     <g id="line2d_13">
       <g>
-       <use xlink:href="#me15a2e6f0d" x="357.917322" y="99.808907" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me0dcc62529" x="507.994534" y="110.040833" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_39">
+     <g id="text_38">
       <!-- 0.04 -->
-      <g transform="translate(332.429432 103.371407) scale(0.095 -0.095)">
+      <g transform="translate(482.506644 113.603333) scale(0.095 -0.095)">
        <use xlink:href="#Helvetica-13"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -1804,15 +2810,43 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_15">
-     <g id="line2d_25">
+    <g id="ytick_6">
+     <g id="line2d_14">
       <g>
-       <use xlink:href="#me15a2e6f0d" x="357.917322" y="75.403573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me0dcc62529" x="507.994534" y="84.110167" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_40">
+     <g id="text_39">
       <!-- 0.05 -->
-      <g transform="translate(332.429432 78.966073) scale(0.095 -0.095)">
+      <g transform="translate(482.506644 87.672667) scale(0.095 -0.095)">
+       <defs>
+        <path id="Helvetica-18" d="M 791 1141 
+Q 847 659 1238 475 
+Q 1438 381 1700 381 
+Q 2200 381 2440 700 
+Q 2681 1019 2681 1406 
+Q 2681 1875 2395 2131 
+Q 2109 2388 1709 2388 
+Q 1419 2388 1211 2275 
+Q 1003 2163 856 1963 
+L 369 1991 
+L 709 4400 
+L 3034 4400 
+L 3034 3856 
+L 1131 3856 
+L 941 2613 
+Q 1097 2731 1238 2791 
+Q 1488 2894 1816 2894 
+Q 2431 2894 2859 2497 
+Q 3288 2100 3288 1491 
+Q 3288 856 2895 371 
+Q 2503 -113 1644 -113 
+Q 1097 -113 676 195 
+Q 256 503 206 1141 
+L 791 1141 
+z
+" transform="scale(0.015625)"/>
+       </defs>
        <use xlink:href="#Helvetica-13"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -1820,15 +2854,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_16">
-     <g id="line2d_26">
+    <g id="ytick_7">
+     <g id="line2d_15">
       <g>
-       <use xlink:href="#me15a2e6f0d" x="357.917322" y="50.99824" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me0dcc62529" x="507.994534" y="58.1795" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_41">
+     <g id="text_40">
       <!-- 0.06 -->
-      <g transform="translate(332.429432 54.56074) scale(0.095 -0.095)">
+      <g transform="translate(482.506644 61.742) scale(0.095 -0.095)">
        <use xlink:href="#Helvetica-13"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -1836,15 +2870,31 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_17">
-     <g id="line2d_27">
+    <g id="ytick_8">
+     <g id="line2d_16">
       <g>
-       <use xlink:href="#me15a2e6f0d" x="357.917322" y="26.592907" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me0dcc62529" x="507.994534" y="32.248833" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_42">
+     <g id="text_41">
       <!-- 0.07 -->
-      <g transform="translate(332.429432 30.155407) scale(0.095 -0.095)">
+      <g transform="translate(482.506644 35.811333) scale(0.095 -0.095)">
+       <defs>
+        <path id="Helvetica-1a" d="M 3347 4400 
+L 3347 3909 
+Q 3131 3700 2773 3181 
+Q 2416 2663 2141 2063 
+Q 1869 1478 1728 997 
+Q 1638 688 1494 0 
+L 872 0 
+Q 1084 1281 1809 2550 
+Q 2238 3294 2709 3834 
+L 234 3834 
+L 234 4400 
+L 3347 4400 
+z
+" transform="scale(0.015625)"/>
+       </defs>
        <use xlink:href="#Helvetica-13"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -1852,9 +2902,35 @@ z
       </g>
      </g>
     </g>
-    <g id="text_43">
+    <g id="text_42">
      <!-- density -->
-     <g transform="translate(326.392869 123.775576) rotate(-90) scale(0.095 -0.095)">
+     <g transform="translate(476.470081 134.564836) rotate(-90) scale(0.095 -0.095)">
+      <defs>
+       <path id="Helvetica-5c" d="M 2503 3347 
+L 3125 3347 
+Q 3006 3025 2597 1878 
+Q 2291 1016 2084 472 
+Q 1597 -809 1397 -1090 
+Q 1197 -1372 709 -1372 
+Q 591 -1372 527 -1362 
+Q 463 -1353 369 -1328 
+L 369 -816 
+Q 516 -856 581 -865 
+Q 647 -875 697 -875 
+Q 853 -875 926 -823 
+Q 1000 -772 1050 -697 
+Q 1066 -672 1162 -440 
+Q 1259 -209 1303 -97 
+L 66 3347 
+L 703 3347 
+L 1600 622 
+L 2503 3347 
+z
+M 1597 3428 
+L 1597 3428 
+z
+" transform="scale(0.015625)"/>
+      </defs>
       <use xlink:href="#Helvetica-47"/>
       <use xlink:href="#Helvetica-48" transform="translate(55.609375 0)"/>
       <use xlink:href="#Helvetica-51" transform="translate(111.21875 0)"/>
@@ -1865,19 +2941,19 @@ z
      </g>
     </g>
    </g>
-   <g id="patch_20">
-    <path d="M 357.917322 197.43024 
-L 357.917322 20.02224 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
    <g id="patch_21">
-    <path d="M 357.917322 197.43024 
-L 512.468047 197.43024 
+    <path d="M 507.994534 213.7635 
+L 507.994534 25.2675 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_44">
+   <g id="patch_22">
+    <path d="M 507.994534 213.7635 
+L 627.166948 213.7635 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_43">
     <!-- σ = 7.3 -->
-    <g style="fill: #4b5563" transform="translate(478.021799 33.86856) scale(0.09 -0.09)">
+    <g style="fill: #4b5563" transform="translate(594.135833 39.55734) scale(0.09 -0.09)">
      <defs>
       <path id="Helvetica-46b" d="M 3878 2866 
 L 3150 2866 
@@ -1913,21 +2989,21 @@ z
      <use xlink:href="#Helvetica-16" transform="translate(258.4375 0)"/>
     </g>
    </g>
-   <g id="text_45">
-    <!-- σ = 8.8 -->
-    <g style="fill: #2563eb" transform="translate(478.021799 51.60936) scale(0.09 -0.09)">
+   <g id="text_44">
+    <!-- σ = 8.7 -->
+    <g style="fill: #2563eb" transform="translate(594.135833 58.40694) scale(0.09 -0.09)">
      <use xlink:href="#Helvetica-46b"/>
      <use xlink:href="#Helvetica-3" transform="translate(61.078125 0)"/>
      <use xlink:href="#Helvetica-20" transform="translate(88.859375 0)"/>
      <use xlink:href="#Helvetica-3" transform="translate(147.265625 0)"/>
      <use xlink:href="#Helvetica-1b" transform="translate(175.046875 0)"/>
      <use xlink:href="#Helvetica-11" transform="translate(230.65625 0)"/>
-     <use xlink:href="#Helvetica-1b" transform="translate(258.4375 0)"/>
+     <use xlink:href="#Helvetica-1a" transform="translate(258.4375 0)"/>
     </g>
    </g>
-   <g id="text_46">
+   <g id="text_45">
     <!-- (b) -->
-    <g transform="translate(362.553844 14.7) scale(0.1 -0.1)">
+    <g transform="translate(511.569707 17.72766) scale(0.1 -0.1)">
      <defs>
       <path id="Helvetica-Bold-45" d="M 2266 -91 
 Q 1844 -91 1588 78 
@@ -1964,11 +3040,11 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p34fe4b285d">
-   <rect x="32.588047" y="20.02224" width="262.736232" height="177.408"/>
+  <clipPath id="pcdef171509">
+   <rect x="240.094948" y="25.2675" width="226.427586" height="188.496"/>
   </clipPath>
-  <clipPath id="p09216fdf78">
-   <rect x="357.917322" y="20.02224" width="154.550725" height="177.408"/>
+  <clipPath id="p32c208dbd8">
+   <rect x="507.994534" y="25.2675" width="119.172414" height="188.496"/>
   </clipPath>
  </defs>
 </svg>


### PR DESCRIPTION
New culture essay: **The tells**.

AI writing now gives itself away at the structural level (corrective negation, rule of three, setup/payoff, landing sentences, uniform rhythm) rather than at the word level. The essay names the shapes with specimens quoted from an earlier post on this site, explains why density is the fingerprint, and documents the guideline change we made: a banned-pattern list in the always-on agent instructions plus a ceiling-not-meter sentence-length rule.

Ships with a density-strip SVG figure (`culture/assets/ai-writing-tells.svg`): human page vs model page, devices as rose dots.

The draft was written under the new rule and self-checked against the tell list before commit.

https://claude.ai/code/session_01GRnw4YSnC3BandkvDCgtaC