### PR TITLE
docs(meta): taxonomy register rules + batch-move redirect script

### DIFF
--- a/_meta/scripts/add-old-url-redirects.py
+++ b/_meta/scripts/add-old-url-redirects.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Append each moved file's OLD live URL to its `redirect:` frontmatter list.
+
+Run from the registers-moves worktree root. Reads the rename map from git
+(origin/main...HEAD), computes the old URL (path sans .md, /readme + /_index
+stripped, README.md -> parent), and inserts it into the YAML frontmatter's
+redirect list (creating the key if absent). Skips files with no frontmatter.
+"""
+import subprocess, sys, re, pathlib
+
+diff = subprocess.run(
+    ["git", "diff", "--name-status", "-M", "origin/main...HEAD"],
+    capture_output=True, text=True, check=True).stdout
+
+renames = []
+for line in diff.splitlines():
+    parts = line.split("\t")
+    if len(parts) == 3 and parts[0].startswith("R") and parts[2].endswith(".md"):
+        renames.append((parts[1], parts[2]))
+
+def old_url(path: str) -> str:
+    p = path[:-3]  # strip .md
+    base = pathlib.PurePosixPath(p)
+    if base.name.lower() in ("readme", "_index"):
+        p = str(base.parent)
+    return "/" + p.strip("/")
+
+changed = skipped = already = 0
+for old, new in renames:
+    f = pathlib.Path(new)
+    if not f.exists():
+        continue
+    text = f.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        skipped += 1
+        continue
+    end = text.index("\n---", 4)
+    fm = text[4:end]
+    url = old_url(old)
+    if url in fm:
+        already += 1
+        continue
+    if re.search(r"^redirect:\s*$", fm, re.M):
+        fm2 = re.sub(r"^redirect:\s*$", f"redirect:\n  - {url}", fm, count=1, flags=re.M)
+    elif re.search(r"^redirect:", fm, re.M):
+        fm2 = re.sub(r"^(redirect:.*)$", rf"\1\n  - {url}", fm, count=1, flags=re.M)
+    else:
+        fm2 = fm + f"\nredirect:\n  - {url}"
+    f.write_text("---\n" + fm2 + text[end:], encoding="utf-8")
+    changed += 1
+
+print(f"renamed md files: {len(renames)}, redirect-added: {changed}, "
+      f"already-had: {already}, no-frontmatter: {skipped}")

--- a/_meta/taxonomy.md
+++ b/_meta/taxonomy.md
@@ -1,0 +1,27 @@
+# Vault taxonomy
+
+One axis per folder. A second classification goes in frontmatter (`tags`, `series`), never a new folder. URL identity = frontmatter `slug` (flat, unique vault-wide); the folder is storage and nav only.
+
+## Registers
+
+| Folder | Holds | Test |
+|---|---|---|
+| `reports/shipped/` | Tier 1 production field reports | live deployment 2+ weeks, real quantitative metrics |
+| `reports/experiment/` | Tier 2 lab reports | internal R&D or benchmark, controlled and reproducible, honest limitations |
+| `reports/lessons/` | Tier 3 retrospectives | hindsight on a past Dwarves project, 3+ months, verified from records |
+| `reports/commentary/` | Tier 4 analysis | practitioner take on external sources, cited, with an original Dwarves angle |
+| `journals/<series>/` | dated recurring series (digest, forward, ogif, changelog, wala, labs-digest) | remove the date and the piece loses meaning |
+| `essays/` | standalone perspective pieces | remove the date and it still reads |
+| `case-studies/` | client project outcomes | |
+| `consulting/` | consulting methodology (navigate, program) | |
+| `site/` | website function pages (services, org, earn, token, contributor-adjacent) | |
+
+## Rules
+
+- `evidence` NEVER appears in frontmatter; the build derives the tier from the path.
+- Reports stay flat: `reports/<tier>/<name>.md`. No nesting.
+- A report that cannot meet its tier's evidence bar gets reclassified down or held, never mislabeled.
+- Journal vs essay: date-anchored entry in a cadence series is a journal; a standalone argument is an essay.
+- Publishing bar (GEO): a page earns existence only if it can win an AI-retrieval query, i.e. firsthand data, a real verdict, or a unique angle.
+- `draft: true` hides a page entirely in production. The pre-migration `updates/` archive is draft-flagged pending triage; un-draft per file, never in bulk.
+- Moving a file: slug stays (URL frozen); append the old path-derived URL to `redirect:` (`_meta/scripts/add-old-url-redirects.py` automates this for a batch), move the folder WITH its sibling `assets/`.


### PR DESCRIPTION
Closes out the Phase-0 item owed to _meta/: tier one-liners, the journal-vs-essay test, slug/draft/move rules, and the GEO publishing bar, per the approved field-report taxonomy brief. Also lands _meta/scripts/add-old-url-redirects.py, the replay tool used in the register-consolidation batch (appends each moved file's old URL to its redirect frontmatter).

https://claude.ai/code/session_01PqQoo7AspRuySEFk2NUY3D