### PR TITLE
feat(commentary): DeepSeek Harness architecture read

### DIFF
--- a/reports/commentary/assets/deepseek-harness-fig1-slot.svg
+++ b/reports/commentary/assets/deepseek-harness-fig1-slot.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 340" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <pattern id="grid" width="26" height="26" patternUnits="userSpaceOnUse">
+      <path d="M 26 0 L 0 0 0 26" fill="none" stroke="#e8f1fa" stroke-opacity="0.05" stroke-width="1"/>
+    </pattern>
+    <marker id="arr" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L8,4 L0,8 z" fill="#c3d7ea"/>
+    </marker>
+  </defs>
+  <rect width="760" height="340" fill="#12395f"/>
+  <rect width="760" height="340" fill="url(#grid)"/>
+  <rect x="0.5" y="0.5" width="759" height="339" fill="none" stroke="#68839d"/>
+  <text x="14" y="24" font-size="10" letter-spacing="1.5" fill="#c3d7ea">FIG. 1 · WHERE DSH SITS</text>
+  <text x="746" y="24" font-size="10" letter-spacing="1.5" fill="#6f8fb0" text-anchor="end">ONE SLOT PER SESSION</text>
+  <line x1="0" y1="36" x2="760" y2="36" stroke="#385a7b"/>
+
+  <rect x="90" y="52" width="580" height="62" fill="#21466a" stroke="#68839d"/>
+  <text x="380" y="76" font-size="12" letter-spacing="2" fill="#e8f1fa" text-anchor="middle">OPERATING LAYER</text>
+  <text x="380" y="98" font-size="10" fill="#a7c0d9" text-anchor="middle">process kit · specs · gates · instruction files (AGENTS.md / CLAUDE.md)</text>
+
+  <line x1="380" y1="114" x2="380" y2="138" stroke="#c3d7ea" marker-end="url(#arr)"/>
+  <text x="392" y="130" font-size="9" letter-spacing="1" fill="#6f8fb0">RUNS ON TOP OF ONE HARNESS</text>
+
+  <rect x="90" y="142" width="580" height="92" fill="none" stroke="#68839d"/>
+  <text x="380" y="164" font-size="12" letter-spacing="2" fill="#e8f1fa" text-anchor="middle">HARNESS LAYER</text>
+  <rect x="106" y="174" width="176" height="34" fill="#21466a" stroke="#68839d"/>
+  <text x="194" y="195" font-size="10" letter-spacing="1" fill="#e8f1fa" text-anchor="middle">CLAUDE CODE</text>
+  <rect x="292" y="174" width="176" height="34" fill="#21466a" stroke="#68839d"/>
+  <text x="380" y="195" font-size="10" letter-spacing="1" fill="#e8f1fa" text-anchor="middle">CODEX CLI</text>
+  <rect x="478" y="174" width="176" height="34" fill="#21466a" stroke="#e8c56a"/>
+  <text x="566" y="195" font-size="10" letter-spacing="1" fill="#e8c56a" text-anchor="middle">DSH</text>
+  <text x="380" y="226" font-size="10" fill="#a7c0d9" text-anchor="middle">agent loop · tools · sessions · MCP · UI</text>
+
+  <line x1="380" y1="234" x2="380" y2="258" stroke="#c3d7ea" marker-end="url(#arr)"/>
+  <text x="392" y="250" font-size="9" letter-spacing="1" fill="#6f8fb0">API CALLS</text>
+
+  <rect x="90" y="262" width="580" height="56" fill="#21466a" stroke="#68839d"/>
+  <text x="380" y="284" font-size="12" letter-spacing="2" fill="#e8f1fa" text-anchor="middle">MODEL LAYER</text>
+  <text x="380" y="304" font-size="10" fill="#a7c0d9" text-anchor="middle">deepseek · anthropic · openai · any openai-compatible endpoint</text>
+</svg>

--- a/reports/commentary/assets/deepseek-harness-fig2-boot.svg
+++ b/reports/commentary/assets/deepseek-harness-fig2-boot.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 420" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <pattern id="grid2" width="26" height="26" patternUnits="userSpaceOnUse">
+      <path d="M 26 0 L 0 0 0 26" fill="none" stroke="#e8f1fa" stroke-opacity="0.05" stroke-width="1"/>
+    </pattern>
+    <marker id="arr2" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L8,4 L0,8 z" fill="#c3d7ea"/>
+    </marker>
+  </defs>
+  <rect width="760" height="420" fill="#12395f"/>
+  <rect width="760" height="420" fill="url(#grid2)"/>
+  <rect x="0.5" y="0.5" width="759" height="419" fill="none" stroke="#68839d"/>
+  <text x="14" y="24" font-size="10" letter-spacing="1.5" fill="#c3d7ea">FIG. 2 · BOOT COMPOSITION</text>
+  <text x="746" y="24" font-size="10" letter-spacing="1.5" fill="#6f8fb0" text-anchor="end">LAYERED PATCHES, NOT A SETTINGS FILE</text>
+  <line x1="0" y1="36" x2="760" y2="36" stroke="#385a7b"/>
+
+  <rect x="40" y="60" width="340" height="44" fill="none" stroke="#6f8fb0" stroke-dasharray="4 3"/>
+  <text x="210" y="86" font-size="10" letter-spacing="1.5" fill="#6f8fb0" text-anchor="middle">EMPTY ROOT</text>
+
+  <rect x="40" y="114" width="340" height="48" fill="#21466a" stroke="#68839d"/>
+  <text x="54" y="134" font-size="10.5" fill="#e8f1fa">+ dsh-base bundle</text>
+  <text x="54" y="151" font-size="9.5" fill="#a7c0d9">models · tools · sandbox · approval · credentials</text>
+
+  <rect x="40" y="172" width="340" height="48" fill="#21466a" stroke="#68839d"/>
+  <text x="54" y="192" font-size="10.5" fill="#e8f1fa">+ dsh-web-app  or  dsh-headless</text>
+  <text x="54" y="209" font-size="9.5" fill="#a7c0d9">the app bundle for the chosen profile</text>
+
+  <rect x="40" y="230" width="340" height="48" fill="#21466a" stroke="#68839d"/>
+  <text x="54" y="250" font-size="10.5" fill="#e8f1fa">+ profile cordis.patch.yml</text>
+  <text x="54" y="267" font-size="9.5" fill="#a7c0d9">user layer, per profile</text>
+
+  <rect x="40" y="288" width="340" height="48" fill="#21466a" stroke="#68839d"/>
+  <text x="54" y="308" font-size="10.5" fill="#e8f1fa">+ $DSH_HOME/cordis.patch.yml</text>
+  <text x="54" y="325" font-size="9.5" fill="#a7c0d9">user layer, home-wide</text>
+
+  <rect x="40" y="346" width="340" height="48" fill="#21466a" stroke="#68839d"/>
+  <text x="54" y="366" font-size="10.5" fill="#e8f1fa">+ --patch overlays</text>
+  <text x="54" y="383" font-size="9.5" fill="#a7c0d9">per invocation</text>
+
+  <line x1="390" y1="227" x2="450" y2="227" stroke="#c3d7ea" marker-end="url(#arr2)"/>
+
+  <rect x="460" y="176" width="262" height="102" fill="none" stroke="#e8c56a"/>
+  <text x="591" y="212" font-size="11" letter-spacing="1.5" fill="#e8c56a" text-anchor="middle">COMPOSED PLUGIN TREE</text>
+  <text x="591" y="236" font-size="9.5" fill="#c3d7ea" text-anchor="middle">every row replaceable by a patch</text>
+  <text x="591" y="253" font-size="9.5" fill="#c3d7ea" text-anchor="middle">by id: replace or insert</text>
+
+  <text x="591" y="310" font-size="10" fill="#a7c0d9" text-anchor="middle">inspect what actually boots:</text>
+  <text x="591" y="330" font-size="10.5" fill="#e8c56a" text-anchor="middle">dsh --profile web --dump-config</text>
+</svg>

--- a/reports/commentary/assets/deepseek-harness-fig3-seams.svg
+++ b/reports/commentary/assets/deepseek-harness-fig3-seams.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 470" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <pattern id="grid3" width="26" height="26" patternUnits="userSpaceOnUse">
+      <path d="M 26 0 L 0 0 0 26" fill="none" stroke="#e8f1fa" stroke-opacity="0.05" stroke-width="1"/>
+    </pattern>
+    <marker id="arr3" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L8,4 L0,8 z" fill="#c3d7ea"/>
+    </marker>
+  </defs>
+  <rect width="760" height="470" fill="#12395f"/>
+  <rect width="760" height="470" fill="url(#grid3)"/>
+  <rect x="0.5" y="0.5" width="759" height="469" fill="none" stroke="#68839d"/>
+  <text x="14" y="24" font-size="10" letter-spacing="1.5" fill="#c3d7ea">FIG. 3 · CONTROL SPINE AND CAPABILITY SEAMS</text>
+  <text x="746" y="24" font-size="10" letter-spacing="1.5" fill="#6f8fb0" text-anchor="end">ONE INTERFACE · N PROVIDERS</text>
+  <line x1="0" y1="36" x2="760" y2="36" stroke="#385a7b"/>
+
+  <rect x="40" y="54" width="680" height="100" fill="#21466a" stroke="#68839d"/>
+  <text x="380" y="78" font-size="12" letter-spacing="2" fill="#e8f1fa" text-anchor="middle">CONTROL SPINE</text>
+  <text x="70" y="102" font-size="10" fill="#c3d7ea">ctx.sessions · append-only event log</text>
+  <text x="70" y="120" font-size="10" fill="#c3d7ea">ctx.agentLoop · the turn driver</text>
+  <text x="70" y="138" font-size="10" fill="#c3d7ea">ctx.tools · guarded tool pipeline</text>
+  <text x="410" y="102" font-size="10" fill="#c3d7ea">ctx.llm · model adapter registry</text>
+  <text x="410" y="120" font-size="10" fill="#c3d7ea">ctx.systemPrompt · prompt assembly</text>
+  <text x="410" y="138" font-size="10" fill="#c3d7ea">ctx.agents · live registry + agent/* events</text>
+
+  <line x1="380" y1="158" x2="380" y2="180" stroke="#c3d7ea" marker-end="url(#arr3)"/>
+  <text x="392" y="174" font-size="9" letter-spacing="1" fill="#6f8fb0">SEAMS: SWAP THE PROVIDER, KEEP THE INTERFACE</text>
+
+  <rect x="40" y="186" width="200" height="38" fill="#21466a" stroke="#68839d"/>
+  <text x="54" y="209" font-size="10.5" fill="#e8f1fa">ctx.fs / ctx.subprocess</text>
+  <rect x="256" y="186" width="464" height="38" fill="none" stroke="#68839d"/>
+  <text x="270" y="209" font-size="10.5" fill="#c3d7ea">local  │  e2b remote sandbox</text>
+
+  <rect x="40" y="232" width="200" height="38" fill="#21466a" stroke="#68839d"/>
+  <text x="54" y="255" font-size="10.5" fill="#e8f1fa">ctx.shell</text>
+  <rect x="256" y="232" width="464" height="38" fill="none" stroke="#68839d"/>
+  <text x="270" y="255" font-size="10.5" fill="#c3d7ea">bash-local  │  bash-sandbox  │  pwsh</text>
+
+  <rect x="40" y="278" width="200" height="38" fill="#21466a" stroke="#e8c56a"/>
+  <text x="54" y="301" font-size="10.5" fill="#e8c56a">ctx.subagent</text>
+  <rect x="256" y="278" width="464" height="38" fill="none" stroke="#e8c56a"/>
+  <text x="270" y="301" font-size="10.5" fill="#e8c56a">in-process  │  acp  │  codex  │  claude code</text>
+
+  <rect x="40" y="324" width="200" height="38" fill="#21466a" stroke="#68839d"/>
+  <text x="54" y="347" font-size="10.5" fill="#e8f1fa">ctx.skills</text>
+  <rect x="256" y="324" width="464" height="38" fill="none" stroke="#68839d"/>
+  <text x="270" y="347" font-size="10.5" fill="#c3d7ea">filesystem discovery  │  bundled</text>
+
+  <rect x="40" y="370" width="200" height="38" fill="#21466a" stroke="#68839d"/>
+  <text x="54" y="393" font-size="10.5" fill="#e8f1fa">ctx.sessionPersistence</text>
+  <rect x="256" y="370" width="464" height="38" fill="none" stroke="#68839d"/>
+  <text x="270" y="393" font-size="10.5" fill="#c3d7ea">jsonl  │  sqlite</text>
+
+  <text x="40" y="442" font-size="9.5" fill="#a7c0d9">fs and subprocess share one execution world: point both at e2b and bash, pty, lsp move to the remote sandbox together.</text>
+</svg>

--- a/reports/commentary/assets/deepseek-harness-fig4-turn.svg
+++ b/reports/commentary/assets/deepseek-harness-fig4-turn.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 330" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <pattern id="grid4" width="26" height="26" patternUnits="userSpaceOnUse">
+      <path d="M 26 0 L 0 0 0 26" fill="none" stroke="#e8f1fa" stroke-opacity="0.05" stroke-width="1"/>
+    </pattern>
+    <marker id="arr4" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L8,4 L0,8 z" fill="#c3d7ea"/>
+    </marker>
+  </defs>
+  <rect width="760" height="330" fill="#12395f"/>
+  <rect width="760" height="330" fill="url(#grid4)"/>
+  <rect x="0.5" y="0.5" width="759" height="329" fill="none" stroke="#68839d"/>
+  <text x="14" y="24" font-size="10" letter-spacing="1.5" fill="#c3d7ea">FIG. 4 · TURN FLOW</text>
+  <text x="746" y="24" font-size="10" letter-spacing="1.5" fill="#6f8fb0" text-anchor="end">A TURN = ZERO OR MORE STEPS</text>
+  <line x1="0" y1="36" x2="760" y2="36" stroke="#385a7b"/>
+
+  <rect x="40" y="70" width="104" height="40" fill="#21466a" stroke="#68839d"/>
+  <text x="92" y="94" font-size="10" letter-spacing="1" fill="#e8f1fa" text-anchor="middle">turn/start</text>
+  <line x1="144" y1="90" x2="168" y2="90" stroke="#c3d7ea" marker-end="url(#arr4)"/>
+
+  <rect x="170" y="62" width="128" height="56" fill="#21466a" stroke="#68839d"/>
+  <text x="234" y="84" font-size="10" letter-spacing="1" fill="#e8f1fa" text-anchor="middle">agent/pre-step</text>
+  <text x="234" y="103" font-size="9" fill="#a7c0d9" text-anchor="middle">rewrite or reject</text>
+  <line x1="298" y1="90" x2="322" y2="90" stroke="#c3d7ea" marker-end="url(#arr4)"/>
+
+  <rect x="324" y="52" width="300" height="118" fill="none" stroke="#e8f1fa"/>
+  <text x="338" y="72" font-size="9" letter-spacing="1.5" fill="#6f8fb0">STEP</text>
+  <rect x="340" y="84" width="84" height="36" fill="#21466a" stroke="#68839d"/>
+  <text x="382" y="101" font-size="9" fill="#e8f1fa" text-anchor="middle">assemble</text>
+  <text x="382" y="113" font-size="9" fill="#a7c0d9" text-anchor="middle">prompt</text>
+  <line x1="424" y1="102" x2="436" y2="102" stroke="#c3d7ea" marker-end="url(#arr4)"/>
+  <rect x="438" y="84" width="84" height="36" fill="#21466a" stroke="#68839d"/>
+  <text x="480" y="101" font-size="9" fill="#e8f1fa" text-anchor="middle">llm request</text>
+  <text x="480" y="113" font-size="9" fill="#a7c0d9" text-anchor="middle">stream chunks</text>
+  <line x1="522" y1="102" x2="534" y2="102" stroke="#c3d7ea" marker-end="url(#arr4)"/>
+  <rect x="536" y="84" width="74" height="36" fill="#21466a" stroke="#68839d"/>
+  <text x="573" y="101" font-size="9" fill="#e8f1fa" text-anchor="middle">tool batch</text>
+  <text x="573" y="113" font-size="9" fill="#a7c0d9" text-anchor="middle">fig. 5</text>
+  <text x="474" y="152" font-size="9" fill="#6f8fb0" text-anchor="middle">step/start … step/end · durable session events</text>
+
+  <path d="M 624 90 L 706 90 L 706 44 L 474 44 L 474 50" fill="none" stroke="#e8c56a" stroke-dasharray="4 3" marker-end="url(#arr4)"/>
+  <text x="698" y="66" font-size="9" fill="#e8c56a" text-anchor="end">tools owe another request: next step</text>
+
+  <line x1="474" y1="170" x2="474" y2="192" stroke="#c3d7ea" marker-end="url(#arr4)"/>
+  <text x="486" y="186" font-size="9" fill="#6f8fb0">nothing owed</text>
+  <rect x="394" y="196" width="160" height="38" fill="#21466a" stroke="#68839d"/>
+  <text x="474" y="219" font-size="10" letter-spacing="1" fill="#e8f1fa" text-anchor="middle">agent/turn-stopping</text>
+  <line x1="554" y1="215" x2="586" y2="215" stroke="#c3d7ea" marker-end="url(#arr4)"/>
+  <rect x="588" y="196" width="104" height="38" fill="#21466a" stroke="#68839d"/>
+  <text x="640" y="219" font-size="10" letter-spacing="1" fill="#e8f1fa" text-anchor="middle">turn/end</text>
+
+  <rect x="40" y="262" width="680" height="42" fill="none" stroke="#e8c56a"/>
+  <text x="380" y="280" font-size="10" letter-spacing="1.5" fill="#e8c56a" text-anchor="middle">INVARIANT · MODEL-VISIBLE MEANS LOGGED</text>
+  <text x="380" y="296" font-size="9.5" fill="#c3d7ea" text-anchor="middle">every model request derives from the append-only session log; a runtime assertion enforces it</text>
+</svg>

--- a/reports/commentary/assets/deepseek-harness-fig5-pipeline.svg
+++ b/reports/commentary/assets/deepseek-harness-fig5-pipeline.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 310" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <pattern id="grid5" width="26" height="26" patternUnits="userSpaceOnUse">
+      <path d="M 26 0 L 0 0 0 26" fill="none" stroke="#e8f1fa" stroke-opacity="0.05" stroke-width="1"/>
+    </pattern>
+    <marker id="arr5" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L8,4 L0,8 z" fill="#c3d7ea"/>
+    </marker>
+  </defs>
+  <rect width="760" height="310" fill="#12395f"/>
+  <rect width="760" height="310" fill="url(#grid5)"/>
+  <rect x="0.5" y="0.5" width="759" height="309" fill="none" stroke="#68839d"/>
+  <text x="14" y="24" font-size="10" letter-spacing="1.5" fill="#c3d7ea">FIG. 5 · TOOL EXECUTION PIPELINE</text>
+  <text x="746" y="24" font-size="10" letter-spacing="1.5" fill="#6f8fb0" text-anchor="end">POLICY ATTACHES WITHOUT CHANGING THE LOOP</text>
+  <line x1="0" y1="36" x2="760" y2="36" stroke="#385a7b"/>
+
+  <rect x="40" y="60" width="125" height="50" fill="#21466a" stroke="#68839d"/>
+  <text x="102" y="80" font-size="9.5" fill="#e8f1fa" text-anchor="middle">tool/call</text>
+  <text x="102" y="96" font-size="8.5" fill="#a7c0d9" text-anchor="middle">logged first</text>
+  <line x1="165" y1="85" x2="173" y2="85" stroke="#c3d7ea" marker-end="url(#arr5)"/>
+
+  <rect x="175" y="60" width="125" height="50" fill="#21466a" stroke="#68839d"/>
+  <text x="237" y="80" font-size="9.5" fill="#e8f1fa" text-anchor="middle">pre-execute</text>
+  <text x="237" y="96" font-size="8.5" fill="#a7c0d9" text-anchor="middle">hooks · permission</text>
+  <line x1="300" y1="85" x2="308" y2="85" stroke="#c3d7ea" marker-end="url(#arr5)"/>
+
+  <rect x="310" y="60" width="125" height="50" fill="#21466a" stroke="#68839d"/>
+  <text x="372" y="80" font-size="9.5" fill="#e8f1fa" text-anchor="middle">guards</text>
+  <text x="372" y="96" font-size="8.5" fill="#a7c0d9" text-anchor="middle">deny or abstain</text>
+  <line x1="435" y1="85" x2="443" y2="85" stroke="#c3d7ea" marker-end="url(#arr5)"/>
+
+  <rect x="445" y="60" width="125" height="50" fill="#21466a" stroke="#68839d"/>
+  <text x="507" y="80" font-size="9.5" fill="#e8f1fa" text-anchor="middle">approval</text>
+  <text x="507" y="96" font-size="8.5" fill="#a7c0d9" text-anchor="middle">ask once, else deny</text>
+  <line x1="570" y1="85" x2="578" y2="85" stroke="#c3d7ea" marker-end="url(#arr5)"/>
+
+  <rect x="580" y="60" width="125" height="50" fill="#21466a" stroke="#68839d"/>
+  <text x="642" y="80" font-size="9.5" fill="#e8f1fa" text-anchor="middle">execute wrap</text>
+  <text x="642" y="96" font-size="8.5" fill="#a7c0d9" text-anchor="middle">timeout · retry</text>
+
+  <path d="M 642 110 L 642 136 L 102 136 L 102 158" fill="none" stroke="#c3d7ea" marker-end="url(#arr5)"/>
+
+  <rect x="40" y="162" width="152" height="50" fill="#21466a" stroke="#68839d"/>
+  <text x="116" y="182" font-size="9.5" fill="#e8f1fa" text-anchor="middle">tool body</text>
+  <text x="116" y="198" font-size="8.5" fill="#a7c0d9" text-anchor="middle">fs writes gated by intents</text>
+  <line x1="192" y1="187" x2="208" y2="187" stroke="#c3d7ea" marker-end="url(#arr5)"/>
+
+  <rect x="210" y="162" width="152" height="50" fill="#21466a" stroke="#68839d"/>
+  <text x="286" y="182" font-size="9.5" fill="#e8f1fa" text-anchor="middle">post-execute</text>
+  <text x="286" y="198" font-size="8.5" fill="#a7c0d9" text-anchor="middle">accept · block · replace</text>
+  <line x1="362" y1="187" x2="378" y2="187" stroke="#c3d7ea" marker-end="url(#arr5)"/>
+
+  <rect x="380" y="162" width="152" height="50" fill="#21466a" stroke="#68839d"/>
+  <text x="456" y="182" font-size="9.5" fill="#e8f1fa" text-anchor="middle">finalize content</text>
+  <text x="456" y="198" font-size="8.5" fill="#a7c0d9" text-anchor="middle">last content invariant</text>
+  <line x1="532" y1="187" x2="548" y2="187" stroke="#c3d7ea" marker-end="url(#arr5)"/>
+
+  <rect x="550" y="162" width="155" height="50" fill="#21466a" stroke="#e8c56a"/>
+  <text x="627" y="182" font-size="9.5" fill="#e8c56a" text-anchor="middle">tool/result</text>
+  <text x="627" y="198" font-size="8.5" fill="#c3d7ea" text-anchor="middle">frozen outcome, logged</text>
+
+  <text x="40" y="252" font-size="9.5" fill="#a7c0d9">same interception points a claude code hook config targets. the difference: typed in-process waterfalls,</text>
+  <text x="40" y="268" font-size="9.5" fill="#a7c0d9">where a listener wraps the call and decides to delegate or short-circuit, instead of shell subprocesses</text>
+  <text x="40" y="284" font-size="9.5" fill="#a7c0d9">speaking exit codes over stdin.</text>
+</svg>

--- a/reports/commentary/deepseek-harness-architecture.md
+++ b/reports/commentary/deepseek-harness-architecture.md
@@ -1,0 +1,112 @@
+---
+title: "DeepSeek Harness, dissected"
+description: "An architecture read of dsh, DeepSeek's new agent harness: the plugin tree, the patch-layer boot, the log-first session model, and what it means for a Claude Code shop."
+date: 2026-08-18
+toc: true
+authors:
+  - tieubao
+tags:
+  - commentary
+  - ai
+  - agents
+  - architecture
+slug: deepseek-harness-architecture
+---
+
+## TL;DR
+
+DeepSeek released an open-source agent harness, `dsh`, and we read the codebase within a day of the drop. Under the "everything is a plugin" tagline sits a real architecture: a Cordis plugin tree composed from ordered patch layers, a small control spine surrounded by swappable capability seams, and one load-bearing invariant that says anything the model sees must derive from an append-only session log. It reads Claude Code instruction files natively, bridges Claude Code hooks, and can even drive Claude Code as a subagent. It is also a developer preview that promises breaking changes. Our verdict: study the design now, run it as a cheap DeepSeek-backed worker if you want, and hold off on betting real automation on it until the plugin API settles.
+
+## 1. Background
+
+An agent harness is the runtime around a model: the loop that assembles prompts, streams responses, executes tool calls, and keeps session state. Claude Code and Codex CLI live in this slot. `dsh` ([deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness)) is DeepSeek's entry, and it crossed 33k GitHub stars within hours of release.
+
+The pitch is architectural. Every part of the product is a plugin on the [Cordis](https://github.com/cordiverse/cordis) framework, including the model adapter, the tool registry, and the agent loop itself. There is no privileged core to patch. You extend it by mounting a plugin beside the others, and every registration is a reversible effect that unwinds when its plugin unloads.
+
+Figure 1 shows where it sits. A harness is one layer of a working stack; the process machinery a team runs on top (specs, gates, review machinery, instruction files) and the models underneath both stay put when the harness changes.
+
+![](assets/deepseek-harness-fig1-slot.svg)
+
+_Fig. 1: dsh occupies the harness slot. It competes with Claude Code and Codex CLI, and it leaves the layers above and below untouched._
+
+## 2. Architecture
+
+### 2.1 Boot: profiles as patch stacks
+
+A running dsh is composed at boot from ordered layers over an empty root (fig. 2). A profile names a stack of bundles, each bundle contributes config rows plus the code they mount, and then the user's patch files apply on top. A patch targets a row by id and either replaces it whole or inserts new rows. `web` and `headless` ship as template profiles.
+
+![](assets/deepseek-harness-fig2-boot.svg)
+
+_Fig. 2: boot composition. The config model is a layered patch stack over a plugin tree, and `--dump-config` prints exactly what your machine boots._
+
+This replaces the flat settings file most harnesses use. The inspectability matters more than the layering: any row the dump prints, a user patch can replace, which turns "can I change this behavior" from a feature request into a config edit.
+
+### 2.2 The spine and the seams
+
+Six core services form the control spine: the session log, the agent registry, the loop driver, the tool registry, prompt assembly, and the model adapter registry. Everything else is a capability seam: a declared interface with swappable providers (fig. 3).
+
+![](assets/deepseek-harness-fig3-seams.svg)
+
+_Fig. 3: the control spine and the seams around it. A seam is three roles: a service definition, a provider, and a consumer._
+
+The seam design carries the most interesting consequences. Filesystem and subprocess providers share one execution world, so pointing both at an [E2B](https://e2b.dev) sandbox moves Bash, PTY, and LSP to remote execution with zero forked tools. The subagent seam goes further: a "subagent" can be an in-process child, an ACP peer, a Codex process, or a Claude Code process, all behind one interface. dsh is built to orchestrate other harnesses, which positions it as a meta-harness over the rest of the field.
+
+### 2.3 The turn loop and its one invariant
+
+A step is one model request plus the tools it calls; a turn is zero or more steps (fig. 4). Live control flows through typed events, and the interesting ones are waterfalls: around-middleware where a listener wraps the call, then either delegates via `next()` or short-circuits to own the decision.
+
+![](assets/deepseek-harness-fig4-turn.svg)
+
+_Fig. 4: turn flow. Durable facts land in the session log; live interception happens on the `agent/*` waterfalls._
+
+The invariant at the bottom of fig. 4 is the soundest piece of the design. Model-visible means logged: anything that reaches a model request must be reconstructable from the append-only session log, and a runtime assertion enforces it. Fork, resume, replay, transcripts, and token metering all derive from that one stream. Context compaction is just another plugin listening for pressure on the pre-step waterfall. The transcript here is the source of truth, and the rest of the system is a projection of it.
+
+### 2.4 The tool pipeline
+
+Tool calls run through a guarded pipeline (fig. 5): pre-execute hooks and permission checks, monotonic guards, a one-shot approval prompt, an execute wrapper for timeouts and retries, then post-execute rewriting before the result freezes into the log.
+
+![](assets/deepseek-harness-fig5-pipeline.svg)
+
+_Fig. 5: the tool execution pipeline. Policy, sandboxing, and rewriting all attach to waterfall events without touching the loop._
+
+These are the same interception points a Claude Code hook config targets. The trade is expressiveness against simplicity: typed in-process waterfalls are strictly more capable than shell subprocesses speaking exit codes over stdin, and they cost you the write-a-bash-script-in-five-minutes accessibility that made Claude Code hooks spread.
+
+## 3. What carries over from a Claude Code setup
+
+We checked the interop surface against a working Claude Code shop:
+
+| Existing asset | dsh support | Mechanism |
+| --- | --- | --- |
+| `AGENTS.md` / `CLAUDE.md` | Native | Walks root to cwd, dedupes identical siblings, injects as durable context, tracks later file changes |
+| Claude Code hooks | Partial bridge | `hooks-claude-code` runs the shell command-hook subset on dsh interception points, with CC-shaped payloads and env substitution |
+| Skills | Concept ports | `ctx.skills` with filesystem discovery and a model-facing loader |
+| MCP servers | Yes | Built-in MCP client |
+| Claude Code itself | As a subagent | `subagent-claude-code` delegates a turn to a Claude Code process |
+| Models | DeepSeek first-class, plus catalog and custom OpenAI-compatible providers | Keys live in `$DSH_HOME/.credentials.yaml`; env-var references supported |
+
+The compatibility posture is deliberate. A team keeps its instruction files and hook scripts on day one, and native plugins remain the upgrade path once something outgrows the bridge.
+
+## 4. Design notes
+
+Three observations from the read, beyond the diagrams.
+
+**The plugin bet is real.** The loop driver itself is a replaceable service. Claude Code exposes fixed extension points; dsh exposes the whole tree. The cost is a steep mental model: Cordis contexts, service injection, reversible effects, and four event dispatch modes stand between you and your first non-trivial plugin.
+
+**Log-first state deserves copying.** "Model-visible means logged" is a design rule any agent runtime can adopt, whatever the framework. It buys deterministic replay and honest token accounting, and it forces every new model-visible feature to declare a durable event type instead of smuggling context in from the side.
+
+**Web-first is a launch choice worth noticing.** The shipped profiles are `web` and `headless`. The docs mention a TUI profile only as a hypothetical install. Terminal-native developers, the crowd Claude Code won first, are visibly second in line here.
+
+## 5. Limitations
+
+The project labels itself a developer preview and promises compatibility-breaking changes, so plugin investments made today may not survive the quarter. DeepSeek's own chat route is text-only; image input needs another provider. And the ecosystem is hours old: lookalike packages appeared on other registries almost immediately, so the official surface is the npm package `@deepseek-ai/dsh` and the `deepseek-ai` GitHub org, nothing else.
+
+## 6. Verdict
+
+For a team already running Claude Code: keep your cockpit, read their session-log design, and try dsh where a cheap DeepSeek-backed headless worker fits (`dsh --profile headless "job"`). The architecture is ahead of the product right now. When the preview label comes off, the interop bridges mean switching costs will be lower than they usually are in this space, and that alone makes it worth tracking.
+
+## References
+
+- [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness), the repository and its `docs/architecture.md`, `docs/cordis-primer.md`, `docs/agent-lifecycle.md`, `docs/tool-execution-pipeline.md`
+- [Cordis](https://github.com/cordiverse/cordis), the plugin framework underneath dsh
+- [Agent Client Protocol](https://agentclientprotocol.com), the editor-integration protocol dsh speaks
+- [E2B](https://e2b.dev), the remote sandbox behind the `fs-e2b` and `subprocess-e2b` providers


### PR DESCRIPTION
New commentary post: an architecture read of dsh (deepseek-ai/deepseek-harness) within a day of release. Science-paper structure, five blueprint-style SVG figures in reports/commentary/assets/. Slug: deepseek-harness-architecture.