### PR TITLE
docs(essays): the deploy pipeline formula

### DIFF
--- a/essays/assets/deploy-pipeline-fig1-timeline.svg
+++ b/essays/assets/deploy-pipeline-fig1-timeline.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 300" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <pattern id="grid" width="26" height="26" patternUnits="userSpaceOnUse">
+      <path d="M 26 0 L 0 0 0 26" fill="none" stroke="#e8f1fa" stroke-opacity="0.05" stroke-width="1"/>
+    </pattern>
+  </defs>
+  <rect width="760" height="300" fill="#12395f"/>
+  <rect width="760" height="300" fill="url(#grid)"/>
+  <rect x="0.5" y="0.5" width="759" height="299" fill="none" stroke="#68839d"/>
+  <text x="14" y="24" font-size="10" letter-spacing="1.5" fill="#c3d7ea">FIG. 1 · THE PUBLISH STEP, BEFORE AND AFTER</text>
+  <text x="746" y="24" font-size="10" letter-spacing="1.5" fill="#6f8fb0" text-anchor="end">SECONDS, TO SCALE</text>
+  <line x1="0" y1="36" x2="760" y2="36" stroke="#385a7b"/>
+
+  <text x="60" y="86" font-size="11" letter-spacing="1.5" fill="#a7c0d9" text-anchor="end">BEFORE</text>
+  <rect x="80" y="66" width="117" height="34" fill="#21466a" stroke="#68839d"/>
+  <text x="138" y="83" font-size="10" fill="#e8f1fa" text-anchor="middle">PREP</text>
+  <text x="138" y="95" font-size="9" fill="#a7c0d9" text-anchor="middle">18s</text>
+  <rect x="197" y="66" width="260" height="34" fill="#21466a" stroke="#68839d"/>
+  <text x="327" y="83" font-size="10" fill="#e8f1fa" text-anchor="middle">BUILD (3,080 PAGES)</text>
+  <text x="327" y="95" font-size="9" fill="#a7c0d9" text-anchor="middle">40s</text>
+  <rect x="457" y="66" width="260" height="34" fill="#21466a" stroke="#68839d"/>
+  <text x="587" y="83" font-size="10" fill="#e8f1fa" text-anchor="middle">DEPLOY TAIL, SERIAL</text>
+  <text x="587" y="95" font-size="9" fill="#a7c0d9" text-anchor="middle">static 17 &#183; api 8 &#183; r2 4 &#183; d1 11 = 40s</text>
+
+  <text x="60" y="156" font-size="11" letter-spacing="1.5" fill="#a7c0d9" text-anchor="end">AFTER</text>
+  <rect x="80" y="136" width="117" height="34" fill="#21466a" stroke="#68839d"/>
+  <text x="138" y="153" font-size="10" fill="#e8f1fa" text-anchor="middle">PREP</text>
+  <text x="138" y="165" font-size="9" fill="#a7c0d9" text-anchor="middle">18s</text>
+  <rect x="197" y="136" width="260" height="34" fill="#21466a" stroke="#68839d"/>
+  <text x="327" y="153" font-size="10" fill="#e8f1fa" text-anchor="middle">BUILD, UNTOUCHED</text>
+  <text x="327" y="165" font-size="9" fill="#a7c0d9" text-anchor="middle">40s</text>
+  <rect x="457" y="136" width="117" height="34" fill="#21466a" stroke="#e8c56a"/>
+  <text x="515" y="153" font-size="10" fill="#e8c56a" text-anchor="middle">TAIL, PARALLEL</text>
+  <text x="515" y="165" font-size="9" fill="#a7c0d9" text-anchor="middle">max() = 18s</text>
+  <line x1="574" y1="153" x2="717" y2="153" stroke="#385a7b" stroke-dasharray="4 4"/>
+  <text x="645" y="147" font-size="9" letter-spacing="1" fill="#6f8fb0" text-anchor="middle">22s RETURNED</text>
+
+  <line x1="0" y1="200" x2="760" y2="200" stroke="#385a7b"/>
+  <text x="14" y="226" font-size="10" letter-spacing="1" fill="#c3d7ea">WHERE THE TIME WENT</text>
+  <text x="14" y="248" font-size="10" fill="#a7c0d9">&#183; the build core was already tight: 27s of Next.js on a warm cache stayed exactly as it was</text>
+  <text x="14" y="266" font-size="10" fill="#a7c0d9">&#183; the whole win came from the tail: three independent jobs were paying sum() instead of max()</text>
+  <text x="14" y="284" font-size="10" fill="#e8c56a">&#183; a memo-only push now also skips the api deploy: the diff proves it cannot have changed</text>
+</svg>

--- a/essays/assets/deploy-pipeline-fig2-dag.svg
+++ b/essays/assets/deploy-pipeline-fig2-dag.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 340" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <pattern id="grid2" width="26" height="26" patternUnits="userSpaceOnUse">
+      <path d="M 26 0 L 0 0 0 26" fill="none" stroke="#e8f1fa" stroke-opacity="0.05" stroke-width="1"/>
+    </pattern>
+    <marker id="arr2" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L8,4 L0,8 z" fill="#c3d7ea"/>
+    </marker>
+    <marker id="arrg" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L8,4 L0,8 z" fill="#e8c56a"/>
+    </marker>
+  </defs>
+  <rect width="760" height="340" fill="#12395f"/>
+  <rect width="760" height="340" fill="url(#grid2)"/>
+  <rect x="0.5" y="0.5" width="759" height="339" fill="none" stroke="#68839d"/>
+  <text x="14" y="24" font-size="10" letter-spacing="1.5" fill="#c3d7ea">FIG. 2 · THE GENERATOR DAG, AND THE STEP THAT RAN TOO EARLY</text>
+  <text x="746" y="24" font-size="10" letter-spacing="1.5" fill="#6f8fb0" text-anchor="end">PARALLEL INSIDE EACH STAGE</text>
+  <line x1="0" y1="36" x2="760" y2="36" stroke="#385a7b"/>
+
+  <text x="90" y="60" font-size="10" letter-spacing="2" fill="#c3d7ea" text-anchor="middle">STAGE A</text>
+  <rect x="20" y="72" width="140" height="40" fill="#21466a" stroke="#68839d"/>
+  <text x="90" y="89" font-size="10" fill="#e8f1fa" text-anchor="middle">metadata</text>
+  <text x="90" y="103" font-size="9" fill="#a7c0d9" text-anchor="middle">memos.json</text>
+
+  <text x="330" y="60" font-size="10" letter-spacing="2" fill="#c3d7ea" text-anchor="middle">STAGE B</text>
+  <rect x="240" y="72" width="180" height="34" fill="#21466a" stroke="#68839d"/>
+  <text x="330" y="93" font-size="10" fill="#e8f1fa" text-anchor="middle">menu &#8594; menu-sorted</text>
+  <rect x="240" y="116" width="180" height="34" fill="#21466a" stroke="#68839d"/>
+  <text x="330" y="137" font-size="10" fill="#e8f1fa" text-anchor="middle">redirects-map</text>
+  <rect x="240" y="160" width="180" height="34" fill="#21466a" stroke="#68839d"/>
+  <text x="330" y="181" font-size="10" fill="#e8f1fa" text-anchor="middle">backlinks</text>
+  <rect x="240" y="204" width="180" height="34" fill="none" stroke="#e8c56a" stroke-dasharray="5 4"/>
+  <text x="330" y="219" font-size="10" fill="#e8c56a" text-anchor="middle">directory-tree</text>
+  <text x="330" y="232" font-size="9" fill="#e8c56a" text-anchor="middle">ran here: inputs did not exist</text>
+
+  <text x="590" y="60" font-size="10" letter-spacing="2" fill="#c3d7ea" text-anchor="middle">STAGE C</text>
+  <rect x="500" y="72" width="180" height="34" fill="#21466a" stroke="#68839d"/>
+  <text x="590" y="93" font-size="10" fill="#e8f1fa" text-anchor="middle">shorten-map</text>
+  <rect x="500" y="116" width="180" height="34" fill="#21466a" stroke="#68839d"/>
+  <text x="590" y="137" font-size="10" fill="#e8f1fa" text-anchor="middle">static-paths</text>
+  <rect x="500" y="170" width="180" height="40" fill="#21466a" stroke="#e8c56a"/>
+  <text x="590" y="187" font-size="10" fill="#e8c56a" text-anchor="middle">directory-tree</text>
+  <text x="590" y="201" font-size="9" fill="#a7c0d9" text-anchor="middle">now after its inputs</text>
+
+  <line x1="160" y1="92" x2="234" y2="89" stroke="#c3d7ea" marker-end="url(#arr2)"/>
+  <line x1="160" y1="98" x2="234" y2="133" stroke="#c3d7ea" marker-end="url(#arr2)"/>
+  <line x1="160" y1="104" x2="234" y2="177" stroke="#c3d7ea" marker-end="url(#arr2)"/>
+  <line x1="420" y1="133" x2="494" y2="89" stroke="#c3d7ea" marker-end="url(#arr2)"/>
+  <line x1="420" y1="139" x2="494" y2="133" stroke="#c3d7ea" marker-end="url(#arr2)"/>
+  <line x1="590" y1="150" x2="590" y2="164" stroke="#e8c56a" marker-end="url(#arrg)"/>
+  <path d="M 420 221 C 460 221 470 240 500 205" fill="none" stroke="#e8c56a" stroke-dasharray="5 4" marker-end="url(#arrg)"/>
+  <text x="462" y="245" font-size="9" letter-spacing="1" fill="#e8c56a" text-anchor="middle">MOVED</text>
+  <line x1="410" y1="93" x2="430" y2="93" stroke="#385a7b"/>
+  <path d="M 420 93 C 470 93 460 170 502 176" fill="none" stroke="#68839d" stroke-dasharray="2 4"/>
+  <text x="447" y="168" font-size="9" fill="#6f8fb0">menu-sorted.json</text>
+
+  <line x1="0" y1="270" x2="760" y2="270" stroke="#385a7b"/>
+  <text x="14" y="292" font-size="10" letter-spacing="1" fill="#c3d7ea">THE FAILURE MODE</text>
+  <text x="14" y="310" font-size="10" fill="#a7c0d9">directory-tree read static-paths.json + menu-sorted.json a stage before they were written,</text>
+  <text x="14" y="326" font-size="10" fill="#a7c0d9">caught the ENOENT, printed "Done (0.8s)", and shipped a tree built from absent inputs. Every publish.</text>
+</svg>

--- a/essays/assets/deploy-pipeline-fig3-tail.svg
+++ b/essays/assets/deploy-pipeline-fig3-tail.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 340" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <pattern id="grid3" width="26" height="26" patternUnits="userSpaceOnUse">
+      <path d="M 26 0 L 0 0 0 26" fill="none" stroke="#e8f1fa" stroke-opacity="0.05" stroke-width="1"/>
+    </pattern>
+    <marker id="arr3" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L8,4 L0,8 z" fill="#c3d7ea"/>
+    </marker>
+  </defs>
+  <rect width="760" height="340" fill="#12395f"/>
+  <rect width="760" height="340" fill="url(#grid3)"/>
+  <rect x="0.5" y="0.5" width="759" height="339" fill="none" stroke="#68839d"/>
+  <text x="14" y="24" font-size="10" letter-spacing="1.5" fill="#c3d7ea">FIG. 3 · THE DEPLOY TAIL: SUM() TO MAX()</text>
+  <text x="746" y="24" font-size="10" letter-spacing="1.5" fill="#6f8fb0" text-anchor="end">SAME JOBS, NEW SHAPE</text>
+  <line x1="0" y1="36" x2="760" y2="36" stroke="#385a7b"/>
+
+  <text x="190" y="60" font-size="10" letter-spacing="2" fill="#a7c0d9" text-anchor="middle">SERIAL &#183; 40s</text>
+  <rect x="110" y="72" width="160" height="30" fill="#21466a" stroke="#68839d"/>
+  <text x="190" y="91" font-size="10" fill="#e8f1fa" text-anchor="middle">static worker &#183; 17s</text>
+  <line x1="190" y1="102" x2="190" y2="114" stroke="#c3d7ea" marker-end="url(#arr3)"/>
+  <rect x="110" y="116" width="160" height="30" fill="#21466a" stroke="#68839d"/>
+  <text x="190" y="135" font-size="10" fill="#e8f1fa" text-anchor="middle">api worker &#183; 8s</text>
+  <line x1="190" y1="146" x2="190" y2="158" stroke="#c3d7ea" marker-end="url(#arr3)"/>
+  <rect x="110" y="160" width="160" height="30" fill="#21466a" stroke="#68839d"/>
+  <text x="190" y="179" font-size="10" fill="#e8f1fa" text-anchor="middle">r2 upload &#183; 4s</text>
+  <line x1="190" y1="190" x2="190" y2="202" stroke="#c3d7ea" marker-end="url(#arr3)"/>
+  <rect x="110" y="204" width="160" height="30" fill="#21466a" stroke="#68839d"/>
+  <text x="190" y="223" font-size="10" fill="#e8f1fa" text-anchor="middle">d1 migrate + seed &#183; 11s</text>
+  <text x="190" y="254" font-size="9" fill="#6f8fb0" text-anchor="middle">also: api deployed BEFORE migrations ran</text>
+
+  <line x1="360" y1="48" x2="360" y2="262" stroke="#385a7b"/>
+
+  <text x="560" y="60" font-size="10" letter-spacing="2" fill="#e8c56a" text-anchor="middle">PARALLEL &#183; 18s</text>
+  <rect x="420" y="72" width="130" height="30" fill="#21466a" stroke="#68839d"/>
+  <text x="485" y="86" font-size="10" fill="#e8f1fa" text-anchor="middle">static worker</text>
+  <text x="485" y="97" font-size="9" fill="#a7c0d9" text-anchor="middle">17s</text>
+  <rect x="420" y="116" width="130" height="30" fill="#21466a" stroke="#68839d"/>
+  <text x="485" y="130" font-size="10" fill="#e8f1fa" text-anchor="middle">r2 upload</text>
+  <text x="485" y="141" font-size="9" fill="#a7c0d9" text-anchor="middle">4s</text>
+  <rect x="420" y="160" width="130" height="42" fill="#21466a" stroke="#68839d"/>
+  <text x="485" y="176" font-size="10" fill="#e8f1fa" text-anchor="middle">d1 migrate &#8594; seed</text>
+  <text x="485" y="190" font-size="9" fill="#a7c0d9" text-anchor="middle">then api deploy</text>
+  <line x1="550" y1="181" x2="580" y2="181" stroke="#c3d7ea" marker-end="url(#arr3)"/>
+  <rect x="582" y="166" width="130" height="30" fill="#21466a" stroke="#e8c56a"/>
+  <text x="647" y="180" font-size="10" fill="#e8c56a" text-anchor="middle">api worker</text>
+  <text x="647" y="191" font-size="9" fill="#a7c0d9" text-anchor="middle">skipped if diff-clean</text>
+  <text x="566" y="223" font-size="9" fill="#a7c0d9">migrations first, code second:</text>
+  <text x="566" y="236" font-size="9" fill="#a7c0d9">new code never meets a missing table</text>
+  <rect x="420" y="72" width="292" height="130" fill="none" stroke="#e8c56a" stroke-dasharray="5 4" opacity="0.5"/>
+
+  <line x1="0" y1="272" x2="760" y2="272" stroke="#385a7b"/>
+  <text x="14" y="294" font-size="10" letter-spacing="1" fill="#c3d7ea">THE RULE</text>
+  <text x="14" y="312" font-size="10" fill="#a7c0d9">independent jobs pay max() when they run as background jobs with collected exit codes;</text>
+  <text x="14" y="328" font-size="10" fill="#a7c0d9">the only real edge is the data-plane order, and it points one way: migrate, then deploy.</text>
+</svg>

--- a/essays/assets/deploy-pipeline-fig4-landed.svg
+++ b/essays/assets/deploy-pipeline-fig4-landed.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 360" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <pattern id="grid4" width="26" height="26" patternUnits="userSpaceOnUse">
+      <path d="M 26 0 L 0 0 0 26" fill="none" stroke="#e8f1fa" stroke-opacity="0.05" stroke-width="1"/>
+    </pattern>
+  </defs>
+  <rect width="760" height="360" fill="#12395f"/>
+  <rect width="760" height="360" fill="url(#grid4)"/>
+  <rect x="0.5" y="0.5" width="759" height="359" fill="none" stroke="#68839d"/>
+  <text x="14" y="24" font-size="10" letter-spacing="1.5" fill="#c3d7ea">FIG. 4 · WHERE IT LANDED: THE FIRST RUN ON THE NEW PIPELINE</text>
+  <text x="746" y="24" font-size="10" letter-spacing="1.5" fill="#6f8fb0" text-anchor="end">BAR WIDTH = SECONDS</text>
+  <line x1="0" y1="36" x2="760" y2="36" stroke="#385a7b"/>
+
+  <text x="240" y="66" font-size="10" fill="#6f8fb0" text-anchor="end">actions overhead</text>
+  <rect x="250" y="52" width="442" height="20" fill="none" stroke="#6f8fb0" stroke-dasharray="4 3"/>
+  <text x="700" y="66" font-size="10" fill="#6f8fb0">34s</text>
+
+  <line x1="250" y1="82" x2="692" y2="82" stroke="#385a7b"/>
+  <text x="250" y="96" font-size="9" letter-spacing="1" fill="#6f8fb0">THE STEP ITSELF</text>
+
+  <text x="240" y="120" font-size="10" fill="#a7c0d9" text-anchor="end">1P env + vault + install</text>
+  <rect x="250" y="106" width="130" height="20" fill="#21466a" stroke="#68839d"/>
+  <text x="388" y="120" font-size="10" fill="#e8f1fa">10s</text>
+
+  <text x="240" y="150" font-size="10" fill="#a7c0d9" text-anchor="end">markdown compile, 1,954 files</text>
+  <rect x="250" y="136" width="117" height="20" fill="#21466a" stroke="#68839d"/>
+  <text x="375" y="150" font-size="10" fill="#e8f1fa">9s</text>
+
+  <text x="240" y="180" font-size="10" fill="#a7c0d9" text-anchor="end">generator DAG, order fixed</text>
+  <rect x="250" y="166" width="65" height="20" fill="#21466a" stroke="#e8c56a"/>
+  <text x="323" y="180" font-size="10" fill="#e8f1fa">5s</text>
+
+  <text x="240" y="210" font-size="10" fill="#a7c0d9" text-anchor="end">next build, 3,080 pages, warm cache</text>
+  <rect x="250" y="196" width="416" height="20" fill="#21466a" stroke="#68839d"/>
+  <text x="674" y="210" font-size="10" fill="#e8f1fa">32s</text>
+
+  <text x="240" y="240" font-size="10" fill="#a7c0d9" text-anchor="end">rss + redirects + cache save</text>
+  <rect x="250" y="226" width="65" height="20" fill="#21466a" stroke="#68839d"/>
+  <text x="323" y="240" font-size="10" fill="#e8f1fa">5s</text>
+
+  <text x="240" y="270" font-size="10" fill="#a7c0d9" text-anchor="end">deploy tail, parallel</text>
+  <rect x="250" y="256" width="234" height="20" fill="#21466a" stroke="#e8c56a"/>
+  <text x="492" y="270" font-size="10" fill="#e8c56a">18s &#183; diff gate fired</text>
+
+  <line x1="0" y1="296" x2="760" y2="296" stroke="#385a7b"/>
+  <text x="14" y="316" font-size="10" letter-spacing="1" fill="#c3d7ea">STEP TOTAL 79s &#183; JOB WALL 113s</text>
+  <text x="14" y="334" font-size="10" fill="#e8c56a">&#183; the diff-clean push skipped the api deploy and the migrations check outright</text>
+  <text x="14" y="350" font-size="10" fill="#a7c0d9">&#183; overhead = runner prep, toolchain setup, 1P CLI download; a different fight with a different owner</text>
+</svg>

--- a/essays/deploy-pipeline-formula.md
+++ b/essays/deploy-pipeline-formula.md
@@ -71,6 +71,22 @@ _Fig. 3: the deploy tail restructured. Same four jobs; the only ordering that ma
 
 The memo-specific parts stay memo-specific: the vault submodule advance, the redirect-map dance around Cloudflare's 2,000-rule cap, the search-index seeds. A formula that claims those would be lying about its portability.
 
+## Where it landed
+
+The first run on the new pipeline, phase by phase, straight from the log:
+
+| Phase | Time |
+| ----- | ---- |
+| 1Password env read + vault fetch + install | 10s |
+| Markdown compile (1,954 files) | 9s |
+| Generator DAG (directory-tree now after its inputs) | 5s |
+| Next.js build (3,080 pages, warm cache) | 32s |
+| RSS, redirects, cache save | 5s |
+| Deploy tail, parallel (api + migrations skipped by the diff gate) | 18s |
+| **Step total** | **79s** |
+
+One honest footnote on the numbers: the job wall clock is ~113 seconds, because about 34 seconds of GitHub Actions overhead (runner prep, toolchain setup, a 1Password CLI download) sits outside the step we measured. We optimized the step because that's where our code runs; the overhead is a different fight with a different owner.
+
 ## The habit underneath
 
 The pipeline was "working" the whole time. Pages published, checks were green, nobody was paged. The 110-second version and the 78-second version look identical from the outside, and the outside is where CI dashboards live. The log with timestamps is the only honest surface a pipeline has. Read it top to bottom once a quarter, or the first time a step's duration makes you frown. Budget an hour. Ours paid for itself before lunch.

--- a/essays/deploy-pipeline-formula.md
+++ b/essays/deploy-pipeline-formula.md
@@ -30,13 +30,21 @@ A CI step hides a dozen phases behind one duration number. The raw log has a tim
 | R2 upload | 4s |
 | D1 seed | 11s |
 
-Two things jump out of a table like this that never jump out of a checkmark. The build core was already tight: 27 seconds for 3,080 pages with a warm compiler cache is fine, and we didn't touch it. The tail was the problem: 40 seconds of deploys and uploads running one after another, none of which depended on each other.
+Two things jump out of a table like this that never jump out of a checkmark. The build core was already tight: 27 seconds for 3,080 pages with a warm compiler cache is fine, and we didn't touch it. The tail was the problem: 40 seconds of deploys and uploads running one after another, none of which depended on each other. Figure 1 shows the same numbers to scale, before and after.
+
+![](assets/deploy-pipeline-fig1-timeline.svg)
+
+_Fig. 1: the publish step to scale. The build core stayed untouched; the entire win came from the tail's shape._
 
 ## The green checkmark was hiding three bugs
 
 Reading that closely also surfaced errors that had been shipping for weeks, because a step that exits 0 gets no scrutiny.
 
-The generator DAG ran one step a stage too early. `generate-directory-tree` reads two JSON files that another generator writes, and it ran in the stage before the one that writes them. It logged an ENOENT stack trace, caught it, and printed "Done (0.8s)". Every publish shipped a directory tree built from files that didn't exist yet. The fix is one line in the stage list, plus the habit the bug taught us: write the dependency reason as a comment next to the stage, so the next person who reorders it has to argue with the comment.
+The generator DAG ran one step a stage too early (fig. 2). `generate-directory-tree` reads two JSON files that another generator writes, and it ran in the stage before the one that writes them. It logged an ENOENT stack trace, caught it, and printed "Done (0.8s)". Every publish shipped a directory tree built from files that didn't exist yet. The fix is one line in the stage list, plus the habit the bug taught us: write the dependency reason as a comment next to the stage, so the next person who reorders it has to argue with the comment.
+
+![](assets/deploy-pipeline-fig2-dag.svg)
+
+_Fig. 2: the generator DAG. The dashed box is where directory-tree used to run; its two inputs are written by the stage it now follows._
 
 The API Worker deployed before its database migrations ran. Nothing had blown up yet because no recent migration was load-bearing at deploy time. The day one is, the new code hits production a few seconds before the table it needs. Expand/contract is the boring, correct order: migrate first, deploy second.
 
@@ -51,11 +59,15 @@ Here's the order we now hold every pipeline to, general first:
 3. Diff the push range per deployable. Our most common push is a memo post; it now skips the API deploy entirely, because the diff proves the API didn't change. Every uncertain answer falls back to deploying, so the skip can only ever be a correct no-op.
 4. Run generators as a staged DAG, parallel inside each stage, with the dependency reason written next to the stage.
 5. Keep caches on the runner. A persistent local dir for the compiler cache beats a 400MB cloud-cache tarball round trip by about 40 seconds.
-6. Run the deploy tail in parallel. Independent jobs cost max() instead of sum(). Ours went from 40 seconds to 18.
+6. Run the deploy tail in parallel. Independent jobs cost max() instead of sum(). Ours went from 40 seconds to 18 (fig. 3).
 7. Migrations before code, always.
 8. Write deltas. Our D1 seeder hash-gates rows ("0 changed of 1,611"), and Wrangler's asset manifest uploads only changed files: one file of 10,921 on a typical post.
 9. Retry idempotent network calls three times. Never retry a step whose repeat changes state.
 10. Sweep hazards by property. Oversized files get dropped by a size test; a filename list rots on the next addition.
+
+![](assets/deploy-pipeline-fig3-tail.svg)
+
+_Fig. 3: the deploy tail restructured. Same four jobs; the only ordering that matters survives inside the data-plane lane, and a diff-clean push skips the api deploy outright._
 
 The memo-specific parts stay memo-specific: the vault submodule advance, the redirect-map dance around Cloudflare's 2,000-rule cap, the search-index seeds. A formula that claims those would be lying about its portability.
 

--- a/essays/deploy-pipeline-formula.md
+++ b/essays/deploy-pipeline-formula.md
@@ -73,19 +73,11 @@ The memo-specific parts stay memo-specific: the vault submodule advance, the red
 
 ## Where it landed
 
-The first run on the new pipeline, phase by phase, straight from the log:
+The first run on the new pipeline, phase by phase, straight from the log (fig. 4):
 
-| Phase | Time |
-| ----- | ---- |
-| 1Password env read + vault fetch + install | 10s |
-| Markdown compile (1,954 files) | 9s |
-| Generator DAG (directory-tree now after its inputs) | 5s |
-| Next.js build (3,080 pages, warm cache) | 32s |
-| RSS, redirects, cache save | 5s |
-| Deploy tail, parallel (api + migrations skipped by the diff gate) | 18s |
-| **Step total** | **79s** |
+![](assets/deploy-pipeline-fig4-landed.svg)
 
-One honest footnote on the numbers: the job wall clock is ~113 seconds, because about 34 seconds of GitHub Actions overhead (runner prep, toolchain setup, a 1Password CLI download) sits outside the step we measured. We optimized the step because that's where our code runs; the overhead is a different fight with a different owner.
+_Fig. 4: the landed shape. The step reads 79 seconds; the job wall clock reads ~113, because 34 seconds of Actions overhead (runner prep, toolchain setup, a 1Password CLI download) sits outside the step we measured._
 
 ## The habit underneath
 

--- a/essays/deploy-pipeline-formula.md
+++ b/essays/deploy-pipeline-formula.md
@@ -1,0 +1,64 @@
+---
+title: The deploy pipeline formula
+description: "Ten ordering rules from cutting memo.d.foundation's publish step from 110 to 78 seconds, and the three silent bugs the green checkmark was hiding."
+date: 2026-08-19
+authors:
+  - tieubao
+tags:
+  - engineering
+  - ci-cd
+  - devops
+  - cloudflare
+slug: deploy-pipeline-formula
+---
+
+The site you're reading publishes itself on every push. A merged post kicks off CI, which compiles about 2,000 markdown files, builds 3,080 static pages, and deploys three Cloudflare surfaces: a static Worker, an API Worker, and a D1 search index. That step showed 1m50s under a green checkmark. We spent a morning reading its raw log line by line. The step now runs in 78 seconds, and the time was the least valuable thing we found.
+
+## Read the log as a timeline
+
+A CI step hides a dozen phases behind one duration number. The raw log has a timestamp on every line, so the first move is to index it: mark where each phase starts, subtract, and write down the table.
+
+| Phase | Time |
+| ----- | ---- |
+| Vault fetch + install | 9s |
+| Markdown compile (1,954 files) | 9s |
+| Metadata generators | 4s |
+| Next.js build (3,080 pages, warm cache) | 27s |
+| RSS, redirects, lint bundle | 9s |
+| Deploy static Worker | 17s |
+| Deploy API Worker | 8s |
+| R2 upload | 4s |
+| D1 seed | 11s |
+
+Two things jump out of a table like this that never jump out of a checkmark. The build core was already tight: 27 seconds for 3,080 pages with a warm compiler cache is fine, and we didn't touch it. The tail was the problem: 40 seconds of deploys and uploads running one after another, none of which depended on each other.
+
+## The green checkmark was hiding three bugs
+
+Reading that closely also surfaced errors that had been shipping for weeks, because a step that exits 0 gets no scrutiny.
+
+The generator DAG ran one step a stage too early. `generate-directory-tree` reads two JSON files that another generator writes, and it ran in the stage before the one that writes them. It logged an ENOENT stack trace, caught it, and printed "Done (0.8s)". Every publish shipped a directory tree built from files that didn't exist yet. The fix is one line in the stage list, plus the habit the bug taught us: write the dependency reason as a comment next to the stage, so the next person who reorders it has to argue with the comment.
+
+The API Worker deployed before its database migrations ran. Nothing had blown up yet because no recent migration was load-bearing at deploy time. The day one is, the new code hits production a few seconds before the table it needs. Expand/contract is the boring, correct order: migrate first, deploy second.
+
+The cleanup job was failing silently on most runs. Our PR-preview reaper runs under `set -euo pipefail`, and its target list came from a `grep` in a pipeline. On any PR with no worker changes, `grep` matches nothing, exits 1, and pipefail kills the step before it can print "nothing to reap". Six red runs in a row, all from the guard clause. `{ grep ... || true; }` is the whole fix.
+
+## The formula
+
+Here's the order we now hold every pipeline to, general first:
+
+1. Path-filter the trigger. A run that starts is the most expensive no-op.
+2. Guard before work: check env vars, read secrets capture-first, fail in seconds instead of after the build.
+3. Diff the push range per deployable. Our most common push is a memo post; it now skips the API deploy entirely, because the diff proves the API didn't change. Every uncertain answer falls back to deploying, so the skip can only ever be a correct no-op.
+4. Run generators as a staged DAG, parallel inside each stage, with the dependency reason written next to the stage.
+5. Keep caches on the runner. A persistent local dir for the compiler cache beats a 400MB cloud-cache tarball round trip by about 40 seconds.
+6. Run the deploy tail in parallel. Independent jobs cost max() instead of sum(). Ours went from 40 seconds to 18.
+7. Migrations before code, always.
+8. Write deltas. Our D1 seeder hash-gates rows ("0 changed of 1,611"), and Wrangler's asset manifest uploads only changed files: one file of 10,921 on a typical post.
+9. Retry idempotent network calls three times. Never retry a step whose repeat changes state.
+10. Sweep hazards by property. Oversized files get dropped by a size test; a filename list rots on the next addition.
+
+The memo-specific parts stay memo-specific: the vault submodule advance, the redirect-map dance around Cloudflare's 2,000-rule cap, the search-index seeds. A formula that claims those would be lying about its portability.
+
+## The habit underneath
+
+The pipeline was "working" the whole time. Pages published, checks were green, nobody was paged. The 110-second version and the 78-second version look identical from the outside, and the outside is where CI dashboards live. The log with timestamps is the only honest surface a pipeline has. Read it top to bottom once a quarter, or the first time a step's duration makes you frown. Budget an hour. Ours paid for itself before lunch.


### PR DESCRIPTION
New essay: the ten ordering rules distilled from this morning's memo publish optimization (110s -> 78s), the three silent bugs behind it (generator DAG ENOENT, migrations-after-deploy, reaper pipefail), and which parts port to other repos.

Placement: essays/ (timeless without the date; today's numbers are the evidence). Slug `deploy-pipeline-formula`, verified unique vault-wide.

Merge does not deploy; after merging, dispatch: `gh workflow run "Memo publish on push" -R dwarvesf/foundation-workers --ref main` (or let the next content push carry it).
