### PR TITLE
fix(content): dead dsql widgets, moved link, unpin a draft

### DIFF
--- a/consulting/README.md
+++ b/consulting/README.md
@@ -19,19 +19,12 @@ This unique setup gives us a competitive edge - we're practitioners backed by cu
 
 ## Latest from consulting team
 
-```dsql-list
-SELECT markdown_link(COALESCE(short_title, title), file_path)
-FROM vault
-WHERE file_path ILIKE '%consulting%'
-  OR ['partners', 'consulting'] && tags
-ORDER BY date DESC
-LIMIT 5;
-```
+Browse the newest consulting posts on the [consulting tag page](/tags/consulting).
 
 ## Series
 
 - [Navigate framework](./navigate): Comprehensive guide to our navigation changes methodology.
-- [Case studies](./case-study): Learn from our practical consulting experiences.
+- [Case studies](/case-studies): Learn from our practical consulting experiences.
 - [Arc](/updates/arc): Deep dive into our research methodology and findings.
 
 ## Key articles for consultants

--- a/essays/README.md
+++ b/essays/README.md
@@ -21,14 +21,7 @@ This collection of articles represents our ongoing exploration of what makes Dwa
 
 ## Latest from culture dir
 
-```dsql-list
-SELECT markdown_link(COALESCE(short_title, title), file_path)
-FROM vault
-WHERE file_path ILIKE '%culture%'
-  OR ['culture', 'culture'] && tags
-ORDER BY date DESC
-LIMIT 20;
-```
+Browse the newest culture writing on the [culture tag page](/tags/culture).
 
 ## What you'll find here
 

--- a/reports/commentary/on-agent.md
+++ b/reports/commentary/on-agent.md
@@ -4,7 +4,6 @@ title: "On agentic AI"
 description: "Our take on the agentic AI wave and how we're positioning ourselves to do more with less"
 date: 2025-06-15
 toc: true
-pinned: true
 authors:
   - tieubao
 tags:


### PR DESCRIPTION
Three regressions from the site screenshots:

- consulting/README.md and essays/README.md carried `dsql-list` widgets from the retired DuckDB pipeline; the TS compiler cannot execute them, so they rendered as a frozen artifact with no content. Replaced with pointers to the live tag pages (/tags/consulting, /tags/culture, both verified 200).
- consulting Series linked ./case-study, which 307s home; now /case-studies.
- reports/commentary/on-agent.md is draft: true but was ALSO pinned: true, pinning a void into the sidebar (/arc-on-agent 307s home). Unpinned; un-drafting stays an editorial call.

Still carrying dead dsql blocks, same one-line fix when touched: site/services/{ai,fintech,web3,platform-ops}.md, site/earn/README.md, journals/digest/digest.md.
