### PR TITLE
feat(home): redesign on the dw brand-token language

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -51,19 +51,19 @@ date: null
         tag: 'engineering',
       },
       {
-        title: 'Blockchain',
-        subtitle: 'Decentralized future',
-        tag: 'blockchain',
-      },
-      {
-        title: 'Wealth',
-        subtitle: 'Growth and prosperity',
-        tag: 'market-report',
-      },
-      {
         title: 'AI',
         subtitle: 'Pushing human limits',
         tag: 'AI',
+      },
+      {
+        title: 'Case studies',
+        subtitle: 'Client work, documented',
+        tag: 'case-study',
+      },
+      {
+        title: 'Consulting',
+        subtitle: 'Field notes from the practice',
+        tag: 'consulting',
       },
     ]} />
 </If>

--- a/index.mdx
+++ b/index.mdx
@@ -96,9 +96,4 @@ date: null
   <a href="/token">🚀 Dwarves+ →</a>
 </div>
 
----
-
-_Written by Dwarves for product craftsmen._\
-_Learned by engineers. Experimented by engineers._
-
 </div>

--- a/index.mdx
+++ b/index.mdx
@@ -4,20 +4,35 @@ description: null
 date: null
 ---
 
-## Welcome to Dwarves Memo
+<header>
+  <div className="dw-eyebrow">Dwarves Foundation · team memo</div>
+  <h1 style={{ marginTop: '6px', marginBottom: '8px', letterSpacing: '-0.02em' }}>
+    Learning in public, <span className="dw-hl">1% at a time</span>
+  </h1>
+  <p style={{ color: 'var(--dw-ink-2)', maxWidth: '60ch', marginTop: 0 }}>
+    This site is our continuous learning engine: engineers writing down what we
+    build, break, and figure out, one memo at a time.
+  </p>
+  <div className="dw-rule" style={{ margin: '18px 0 14px' }} />
+</header>
 
-This site is a part of our continuous learning engine, where we want to build up the 1% improvement habit, learning in public.
+<div className="dw-card" style={{ padding: '16px 20px', marginBottom: '8px' }}>
+  <div className="dw-eyebrow" style={{ marginBottom: '8px' }}>Now</div>
 
-> Ecclesiastes 7:12:
-> "For wisdom is a defence, and money is a defence: but the excellency of knowledge is, that wisdom giveth life to them that have it."
+  - Fresh research: [the deploy pipeline formula](/deploy-pipeline-formula), [DeepSeek Harness, dissected](/deepseek-harness-architecture)
+  - Hiring: [🧠 growth lead](careers/open-positions/growth-lead.md), [💼 sales manager](careers/open-positions/sales-manager.md), [💻 software engineer](careers/open-positions/software-engineer.md)
+  - Just shipped: [Dwarves+ tokenomics](/token), [our build log](/build-log)
+</div>
 
-- Research: [on agent](updates/arc/on-agent.md), [monitoring](updates/build-log/monitoring/readme.md), [vibe coding](updates/build-log/vibe-coding/readme.md)
-- Latest report: [2025 May report](updates/forward/2025-05.md)
-- Hiring: [🧠 growth lead](careers/open-positions/growth-lead.md), [💼 sales manager](careers/open-positions/sales-manager.md), [💻 software engineer](careers/open-positions/software-engineer.md)
-- Just shipped: [Dwarves+ tokenomics](misc/tokenomics/README.md), [company](updates/build-log/company/readme.md), [brainery](updates/build-log/brainery/readme.md), [memo](updates/build-log/memo/readme.md), [mcp-playbook](updates/build-log/playbook/readme.md)
+<div className="dw-band">
+  <span className="dw-band-label">① Worth reading</span>
+  <span className="dw-band-sub">the four desks we write from</span>
+  <span className="dw-band-rule" />
+</div>
 
 <If condition={memosWithTags}>
-  <WorthReading 
+  <WorthReading
+    hideTitle
     memos={memosWithTags}
     blocks={[
       {
@@ -43,53 +58,45 @@ This site is a part of our continuous learning engine, where we want to build up
     ]} />
 </If>
 
+<div className="dw-band">
+  <span className="dw-band-label">② Latest memos</span>
+  <span className="dw-band-sub">everything else, newest first</span>
+  <span className="dw-band-rule" />
+</div>
+
 <If condition={memosWithTags}>
-  <MemoFilterList title="Latest memos" all={memosWithTags} filters={['web3', 'design', 'culture']} />
+  <MemoFilterList title="" all={memosWithTags} filters={['web3', 'design', 'culture']} />
 </If>
 
 <TagsMarquee directoryTree={directoryTree} />
 
-<div className="love-watch-we-are-doing">
-  <h2>
-    Love what we are doing?
-  </h2>
-  <ul>
-    <li>
-      <a
-        href="https://discord.gg/dfoundation"
-        className="text-primary text-sm" >
-        🩷 Join our Discord Network →
-      </a>
-    </li>
-    <li>
-      <a
-        href="https://github.com/dwarvesf/playground"
-        className="!text-primary text-sm" >
-        🔥 Contribute to our Memo →
-      </a>
-    </li>
-    <li>
-      <a
-        href="https://careers.d.foundation/"
-        className="text-primary text-sm" >
-        🤝 Join us, we are hiring →
-      </a>
-    </li>
-    <li>
-      <a
-        href="http://memo.d.foundation/earn/"
-        className="text-primary text-sm" >
-        🙋 Give us a helping hand →
-      </a>
-    </li>
-    <li>
-      <a
-        href="/misc/tokenomics/"
-        className="text-primary text-sm" >
-        🚀 Explore Dwarves+ Protocol →
-      </a>
-    </li>
-  </ul>
+<div className="dw-band">
+  <span className="dw-band-label">③ Join in</span>
+  <span className="dw-band-sub">five doors into the network</span>
+  <span className="dw-band-rule" />
+</div>
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(210px, 1fr))', gap: '12px' }}>
+  <a className="dw-tile" style={{ textDecoration: 'none' }} href="https://discord.gg/dfoundation">
+    <div className="dw-tile-v" style={{ fontSize: '19px' }}>🩷 Discord</div>
+    <div className="dw-tile-l">Join the network, talk shop with us</div>
+  </a>
+  <a className="dw-tile" style={{ textDecoration: 'none' }} href="https://github.com/dwarvesf/playground">
+    <div className="dw-tile-v" style={{ fontSize: '19px' }}>🔥 Contribute</div>
+    <div className="dw-tile-l">Write for the memo, PRs welcome</div>
+  </a>
+  <a className="dw-tile" style={{ textDecoration: 'none' }} href="https://careers.d.foundation/">
+    <div className="dw-tile-v" style={{ fontSize: '19px' }}>🤝 Join us</div>
+    <div className="dw-tile-l">We are hiring, three roles open</div>
+  </a>
+  <a className="dw-tile" style={{ textDecoration: 'none' }} href="/earn">
+    <div className="dw-tile-v" style={{ fontSize: '19px' }}>🙋 Earn</div>
+    <div className="dw-tile-l">Give us a helping hand, get ICY</div>
+  </a>
+  <a className="dw-tile" style={{ textDecoration: 'none' }} href="/token">
+    <div className="dw-tile-v" style={{ fontSize: '19px' }}>🚀 Dwarves+</div>
+    <div className="dw-tile-l">Explore the protocol and tokenomics</div>
+  </a>
 </div>
 
 ---

--- a/index.mdx
+++ b/index.mdx
@@ -78,7 +78,9 @@ date: null
   <MemoFilterList title="" all={memosWithTags} filters={['web3', 'design', 'culture']} />
 </If>
 
-<TagsMarquee directoryTree={directoryTree} />
+<div className="dw-marquee">
+  <TagsMarquee directoryTree={directoryTree} />
+</div>
 
 <div className="dw-band">
   <span className="dw-band-label">Join in</span>

--- a/index.mdx
+++ b/index.mdx
@@ -9,10 +9,10 @@ date: null
   <h1 style={{ marginTop: '6px', marginBottom: '8px', letterSpacing: '-0.02em' }}>
     Learning in public, <span className="dw-hl">1% at a time</span>
   </h1>
-  <p style={{ color: 'var(--dw-ink-2)', maxWidth: '60ch', marginTop: 0 }}>
+  <div style={{ color: 'var(--dw-ink-2)', maxWidth: '60ch' }}>
     This site is our continuous learning engine: engineers writing down what we
     build, break, and figure out, one memo at a time.
-  </p>
+  </div>
   <div className="dw-rule" style={{ margin: '18px 0 14px' }} />
 </header>
 

--- a/index.mdx
+++ b/index.mdx
@@ -4,34 +4,44 @@ description: null
 date: null
 ---
 
+<div className="dw-home">
+
 <header>
-  <div className="dw-eyebrow">Dwarves Foundation · team memo</div>
-  <h1 style={{ marginTop: '6px', marginBottom: '8px', letterSpacing: '-0.02em' }}>
-    Learning in public, <span className="dw-hl">1% at a time</span>
-  </h1>
-  <div style={{ color: 'var(--dw-ink-2)', maxWidth: '60ch' }}>
-    This site is our continuous learning engine: engineers writing down what we
-    build, break, and figure out, one memo at a time.
+  <div className="dw-masthead">
+    <div>
+      <div className="dw-eyebrow">Dwarves Foundation · team memo</div>
+      <h1 className="dw-verdict" style={{ marginTop: '6px' }}>
+        We write down what we build, break, and figure out, <span className="dw-hl">before we forget it</span>.
+      </h1>
+    </div>
+    <div className="dw-stamp">est. 2013 · new memos weekly</div>
   </div>
-  <div className="dw-rule" style={{ margin: '18px 0 14px' }} />
+  <div className="dw-verdict-sub">
+    The team's continuous learning engine: engineering, blockchain, markets,
+    and AI, one memo at a time, learning in public.
+  </div>
+  <div className="dw-rule" style={{ margin: '18px 0 6px' }} />
 </header>
 
-<div className="dw-card" style={{ padding: '16px 20px', marginBottom: '8px' }}>
-  <div className="dw-eyebrow" style={{ marginBottom: '8px' }}>Now</div>
-
-  - Fresh research: [the deploy pipeline formula](/deploy-pipeline-formula), [DeepSeek Harness, dissected](/deepseek-harness-architecture)
-  - Hiring: [🧠 growth lead](careers/open-positions/growth-lead.md), [💼 sales manager](careers/open-positions/sales-manager.md), [💻 software engineer](careers/open-positions/software-engineer.md)
-  - Just shipped: [Dwarves+ tokenomics](/token), [our build log](/build-log)
+<div className="dw-band">
+  <span className="dw-band-label">Now</span>
+  <span className="dw-band-sub">fresh off the desks</span>
+  <span className="dw-band-rule" />
 </div>
 
+- Fresh research: [the deploy pipeline formula](/deploy-pipeline-formula), [DeepSeek Harness, dissected](/deepseek-harness-architecture)
+- Hiring: [🧠 growth lead](careers/open-positions/growth-lead.md), [💼 sales manager](careers/open-positions/sales-manager.md), [💻 software engineer](careers/open-positions/software-engineer.md)
+- Just shipped: [Dwarves+ tokenomics](/token), [our build log](/build-log)
+
 <div className="dw-band">
-  <span className="dw-band-label">① Worth reading</span>
+  <span className="dw-band-label">Worth reading</span>
   <span className="dw-band-sub">the four desks we write from</span>
   <span className="dw-band-rule" />
 </div>
 
 <If condition={memosWithTags}>
   <WorthReading
+    variant="desk"
     hideTitle
     memos={memosWithTags}
     blocks={[
@@ -51,7 +61,7 @@ date: null
         tag: 'market-report',
       },
       {
-        title: 'Artificial Intelligence',
+        title: 'AI',
         subtitle: 'Pushing human limits',
         tag: 'AI',
       },
@@ -59,7 +69,7 @@ date: null
 </If>
 
 <div className="dw-band">
-  <span className="dw-band-label">② Latest memos</span>
+  <span className="dw-band-label">Latest memos</span>
   <span className="dw-band-sub">everything else, newest first</span>
   <span className="dw-band-rule" />
 </div>
@@ -71,35 +81,22 @@ date: null
 <TagsMarquee directoryTree={directoryTree} />
 
 <div className="dw-band">
-  <span className="dw-band-label">③ Join in</span>
-  <span className="dw-band-sub">five doors into the network</span>
+  <span className="dw-band-label">Join in</span>
+  <span className="dw-band-sub">doors into the network</span>
   <span className="dw-band-rule" />
 </div>
 
-<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(210px, 1fr))', gap: '12px' }}>
-  <a className="dw-tile" style={{ textDecoration: 'none' }} href="https://discord.gg/dfoundation">
-    <div className="dw-tile-v" style={{ fontSize: '19px' }}>🩷 Discord</div>
-    <div className="dw-tile-l">Join the network, talk shop with us</div>
-  </a>
-  <a className="dw-tile" style={{ textDecoration: 'none' }} href="https://github.com/dwarvesf/playground">
-    <div className="dw-tile-v" style={{ fontSize: '19px' }}>🔥 Contribute</div>
-    <div className="dw-tile-l">Write for the memo, PRs welcome</div>
-  </a>
-  <a className="dw-tile" style={{ textDecoration: 'none' }} href="https://careers.d.foundation/">
-    <div className="dw-tile-v" style={{ fontSize: '19px' }}>🤝 Join us</div>
-    <div className="dw-tile-l">We are hiring, three roles open</div>
-  </a>
-  <a className="dw-tile" style={{ textDecoration: 'none' }} href="/earn">
-    <div className="dw-tile-v" style={{ fontSize: '19px' }}>🙋 Earn</div>
-    <div className="dw-tile-l">Give us a helping hand, get ICY</div>
-  </a>
-  <a className="dw-tile" style={{ textDecoration: 'none' }} href="/token">
-    <div className="dw-tile-v" style={{ fontSize: '19px' }}>🚀 Dwarves+</div>
-    <div className="dw-tile-l">Explore the protocol and tokenomics</div>
-  </a>
+<div className="dw-join">
+  <a href="https://discord.gg/dfoundation">🩷 discord →</a>
+  <a href="https://github.com/dwarvesf/playground">🔥 contribute →</a>
+  <a href="https://careers.d.foundation/">🤝 join us →</a>
+  <a href="/earn">🙋 earn ICY →</a>
+  <a href="/token">🚀 Dwarves+ →</a>
 </div>
 
 ---
 
 _Written by Dwarves for product craftsmen._\
 _Learned by engineers. Experimented by engineers._
+
+</div>


### PR DESCRIPTION
The homepage rebuilt on the fw feat/memo-brand-home token layer: eyebrow + crimson-highlight hero + dither rule, a NOW card (links updated to live pages; the old research/report links 307'd to home), numbered banded sections, and the five join links as tiles. Screenshots: fw docs/verification/memo-brand-home/. Merge together with the fw PR; goes live on the next publish after both land.