### PR TITLE
fix: repair mechanically-broken links (playbook TOC, mbti paths, mailtos, schemes)

### DIFF
--- a/about.md
+++ b/about.md
@@ -23,7 +23,7 @@ Applying the Zettelkasten method to construct our reference neuron network, we c
 
 We encourage our members to read, write, share what we learn with others, and [contributing to the Brainery](CONTRIBUTING.md) is an important part of our learning culture.
 
-For visitors, you are welcome to read them, contribute to them, and [suggest additions](discord.gg/dfoundation). We maintain a monthly pool of $1500 to reward contributors who support our journey of lifelong growth in knowledge and network.
+For visitors, you are welcome to read them, contribute to them, and [suggest additions](https://discord.gg/dfoundation). We maintain a monthly pool of $1500 to reward contributors who support our journey of lifelong growth in knowledge and network.
 
 ### Dwarves+ Protocol
 

--- a/site/services/fintech.md
+++ b/site/services/fintech.md
@@ -114,7 +114,7 @@ Whether you're a fintech startup or an established bank looking to modernize, we
 
 **Email**: <team@d.foundation>
 **Phone**: (+1) 818 408 6969
-**Telegram**: [dfoundation](t.me/dfoundation)
+**Telegram**: [dfoundation](https://t.me/dfoundation)
 
 ## Learn more
 

--- a/site/services/web3.md
+++ b/site/services/web3.md
@@ -124,7 +124,7 @@ Whether you're exploring blockchain for the first time or scaling an existing We
 
 **Email**: <team@d.foundation>  
 **Phone**: (+1) 818 408 6969  
-**Telegram**: [dfoundation](t.me/dfoundation)  
+**Telegram**: [dfoundation](https://t.me/dfoundation)  
 
 - [View our team](https://memo.d.foundation/profile)
 - [See more case studies](https://memo.d.foundation/consulting)


### PR DESCRIPTION
## Summary

Mechanical-only slice of the memo.d.foundation link audit (#227). This
PR covers Class 4 (scheme-less externals) in this repo directly.
Classes 1-3 live in submodules with mixed writability; status for
each below so the full picture is in one place.

## Class 4: scheme-less externals (this PR, 3/3 fixed)

`t.me/dfoundation` and `discord.gg/dfoundation` written without a
`https://` scheme render as broken site-relative paths instead of
external links.

| File | Old | New | Probe |
|---|---|---|---|
| `site/services/fintech.md` | `[dfoundation](t.me/dfoundation)` | `[dfoundation](https://t.me/dfoundation)` | 200 |
| `site/services/web3.md` | `[dfoundation](t.me/dfoundation)` | `[dfoundation](https://t.me/dfoundation)` | 200 |
| `about.md` | `[suggest additions](discord.gg/dfoundation)` | `[suggest additions](https://discord.gg/dfoundation)` | 301 -> `discord.com/invite/dfoundation` -> 200 |

`site/services/ai.md` and `site/services/platform-ops.md` already had
the `https://` prefix, so left untouched.

## Class 1: playbook TOC (44/52 fixed, blocked on push)

`playbook/README.md` (renders as `/playbook/readme`) had 52 internal
absolute links written pre-restructure (`/design/<x>`,
`/engineering/<x>`, `/business/readme`). 44 are fixed and verified
200 on memo.d.foundation, committed locally on a
`fix/dead-links-mechanical` branch in the `playbook` submodule
checkout, commit `4bbeb2a`.

**Blocked: `dwarvesf/playbook` is archived (read-only) on GitHub.**
`git push` fails with "This repository was archived so it is
read-only." The fix exists and is verified but cannot land as a PR
until the repo is unarchived (or the content is migrated elsewhere).
8 links left as-is regardless (draft pages or genuinely missing
files): `design/wireframe`, `design/IA`, `design/UI`, `design/IX`,
`design/design-system` (all `draft: true`), `business/README.md`,
`business/fbsc.md`, `collaboration-guideline.md` (no matching file
in the repo).

## Class 2: MBTI obsidian-mangled paths (10/10 fixed, separate PR)

Fixed and opened as dwarvesf/research#552 (`research` submodule is
not archived). 10 raw `obsidian://open?vault=...&file=...` URIs
across 6 files under `notes/hr/mbti/` rewritten to their live
site-relative paths, each verified 200.

## Class 3: mangled mailtos (0 changes needed)

Checked all four described locations (`careers/archived/`,
`careers/open-positions/`, `careers/README.md`,
`consulting/partners-network.md`). **The source is already fixed** -
`dwarvesf/WeAreHiring` commit `032ee61` ("fix urls", 2025-06-02)
already rewrote every mailto to proper `mailto:` syntax. Confirmed
by grep: zero broken-form mailtos remain in the `careers` or
`consulting` trees.

The live site is still serving the broken form though (e.g.
`https://memo.d.foundation/careers/archived/frontend-developer-junior`
still renders `mailtospawnd.foundation` in its HTML) - that's a stale
memo.d.foundation build, not a content problem, and out of scope for
a content PR. `dwarvesf/WeAreHiring` is also now archived, so no
further source PR is possible there either way.

## Left-as-is summary

| Item | Reason |
|---|---|
| `playbook/README.md` fix (44 links) | verified + committed locally, but `dwarvesf/playbook` is archived, cannot push |
| `design/wireframe`, `IA`, `UI`, `IX`, `design-system` | `draft: true`, no live page to link to |
| `business/README.md`, `business/fbsc.md`, `collaboration-guideline.md` | no matching file anywhere in `playbook` |
| Class 3 mailtos | already fixed in source; live site is a stale build, not a content issue |

Ref: #227
