### PR TITLE
feat: arc redirects, publish on-agent and route the removed section

### DIFF
--- a/reports/commentary/on-agent.md
+++ b/reports/commentary/on-agent.md
@@ -1,5 +1,5 @@
 ---
-draft: true
+draft: false
 title: "On agentic AI"
 description: "Our take on the agentic AI wave and how we're positioning ourselves to do more with less"
 date: 2025-06-15
@@ -13,6 +13,7 @@ tags:
   - ai-strategy
 redirect:
   - /Bg60FM
+  - /arc/on-agent
 slug: arc-on-agent
 ---
 

--- a/site/org/2025/roadmap-2025.md
+++ b/site/org/2025/roadmap-2025.md
@@ -14,6 +14,10 @@ tags:
 redirect:
   - /org/2025/roadmap-2025
   - /8ike6A
+  - /arc
+  - /arc/on-blockchain
+  - /arc/on-platform
+  - /arc/on-spatial
 slug: org-roadmap-2025
 ---
 


### PR DESCRIPTION
Closes class 3 of #227, per owner direction (redirects, not link edits).

| Old URL | Now 301s to | Via |
|---|---|---|
| `/arc/on-agent` | `/arc-on-agent` | `reports/commentary/on-agent.md` un-drafted (it is the owner's own commentary, already slugged) |
| `/arc`, `/arc/on-blockchain`, `/arc/on-platform`, `/arc/on-spatial` | `/org-roadmap-2025` | redirect entries on the roadmap, where those theses live in prose |

Note for the merger: this un-drafts one page (on-agent). If it was meant to stay hidden, drop that hunk and its redirect entry before merging.

Companion infra shipped separately today: eleven retired `*.d.foundation` subdomains and `stt/mm.daf.ug` now 301 (DNS records restored onto existing page rules plus new redirect rules), closing most of class 5.