### PR TITLE
fix: restore arc-convergence to published

### DIFF
--- a/reports/commentary/arc-convergence.md
+++ b/reports/commentary/arc-convergence.md
@@ -1,5 +1,5 @@
 ---
-draft: true
+draft: false
 title: The convergence
 description: How every technology wave we track ultimately serves our four foundational verticals. This is where individual arcs converge into our long-term strategy for empowering innovation.
 date: 2025-01-14


### PR DESCRIPTION
Owner-directed check of the arc posts' history settled it: they were normal posts under `updates/arc/` until the June archive sweep (#204, "demote lookup/log notes") draft-flagged them as collateral, and the August taxonomy move (#217) relocated them to `reports/commentary/`. `on-llm` was never flagged and has been live all along at `/arc-on-llm`; `on-agent` was restored earlier today (#231); this restores the third and last, `arc-convergence` (The convergence).

Also settled: `/arc/on-blockchain`, `/arc/on-platform`, `/arc/on-spatial` never existed as posts anywhere in history; the roadmap links were aspirational. Their 301s to `/org-roadmap-2025` (#231) are the correct ending, not a placeholder.