### PR TITLE
docs(readme): fix stale publish-repo description

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ We use the Obsidian plugin [Local Images Plus](https://github.com/Sergei-Korneev
 
 ## How does this all work?
 
-We essentially have 2 repositories:
+This repo holds the vault; two other repos handle publishing, split by plane:
 
-1. One to manage the compilation and deployment of Obsidian markdown to static HTML: <https://github.com/dwarvesf/memo.d.foundation>
-2. One to manage the vault that everyone interacts with; think of Obsidian as our IDE or local CMS: <https://github.com/dwarvesf/brainery>
+1. `dwarvesf/foundation-workers`: the data plane, memo-api, D1 seeders, the search index, menus, the rollup, the R2 derived upload.
+2. `dwarvesf/foundation-apps`: the `df-memo` static frontend, the Worker that actually serves <https://memo.d.foundation>.
 
-Any changes to any one of these repositories will initiate a deployment workflow on the first repository, which will then update changes to <https://memo.d.foundation>.
+A push to `main` here dispatches both, content-only, so a memo post publishes without minting a Release in either repo. `dwarvesf/memo.d.foundation` is the retired predecessor repo; it is archived and no longer part of the publish path.


### PR DESCRIPTION
## Doc-drift fix: stale publish-repo description in README

Part of the whole-estate doc-drift audit for the 2026-08-20 memo/dataroom
estate change. `.github/workflows/publish-on-push.yml` in this repo already
documents the current split correctly (header comment, dated 2026-08-20);
`README.md`'s "How does this all work?" section did not.

**Before (stale):**

> We essentially have 2 repositories:
> 1. One to manage the compilation and deployment of Obsidian markdown to
>    static HTML: https://github.com/dwarvesf/memo.d.foundation
> 2. One to manage the vault that everyone interacts with...
>
> Any changes to any one of these repositories will initiate a deployment
> workflow on the first repository, which will then update changes to
> https://memo.d.foundation.

`dwarvesf/memo.d.foundation` is archived (verified via `gh api
repos/dwarvesf/memo.d.foundation`). It has not been the deploy repo for a
while; the actual current split (already correct in this repo's own
workflow file) is:

- `dwarvesf/foundation-workers`: data plane (memo-api, D1 seeders, search
  index, menus, rollup, R2 derived upload)
- `dwarvesf/foundation-apps`: the `df-memo` static frontend Worker

Both are dispatched from this repo's `publish-on-push.yml` on a content
push. This PR only rewrites the README prose to match; no workflow logic
changed.

Not merging; branch + PR only per the audit's rules.
