### PR TITLE
fix(home): stop MDX from wrapping the h1 text in a p tag

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -10,9 +10,7 @@ date: null
   <div className="dw-masthead">
     <div>
       <div className="dw-eyebrow">Dwarves Foundation · team memo</div>
-      <h1 className="dw-verdict" style={{ marginTop: '6px' }}>
-        We write down what we build, break, and figure out, <span className="dw-hl">before we forget it</span>.
-      </h1>
+      <h1 className="dw-verdict" style={{ marginTop: '6px' }}>We write down what we build, break, and figure out, <span className="dw-hl">before we forget it</span>.</h1>
     </div>
     <div className="dw-stamp">est. 2013 · new memos weekly</div>
   </div>


### PR DESCRIPTION
## Problem

The memo homepage renders an invalid heading in production:

```
<h1 class="dw-verdict" style="margin-top:6px"><p>We write down what we build, break, and figure out, <span class="dw-hl">before we forget it</span>.</p></h1>
```

Verified live: `curl -s https://memo.d.foundation/ | grep -o '<h1[^>]*>.\{0,200\}'`.

A `<p>` is not allowed inside `<h1>` per the HTML heading content model. The is-agentic.com scanner reads this as "no H1 tag" and fails an otherwise-passing check.

## Root cause

`index.mdx` wrote the h1's text on lines indented below the opening tag:

```jsx
<h1 className="dw-verdict" style={{ marginTop: '6px' }}>
  We write down what we build, break, and figure out, <span className="dw-hl">before we forget it</span>.
</h1>
```

MDX classifies a JSX element as block-level (flow) when its children start on a new line rather than immediately after the opening tag. Once treated as flow, remark parses the inner text with the block tokenizer, which wraps a bare run of text in a paragraph node before the JSX ever sees it, the same rule that turns loose text inside any markdown container into a `<p>`. That paragraph then becomes the h1's only child.

Confirmed against the exact compiler the memo app uses (`@mdx-js/mdx@3.1.1`, resolved from `foundation-apps`' own `node_modules`, `next-mdx-remote-client` -> `serialize()` -> `@mdx-js/mdx`), compiling `index.mdx` before and after the change:

- Before: `children: _jsxs(_components.p, { children: [...] })`
- After: `children: ["We write down what we build...", _jsx("span", {...}), "."]`

## Fix

Put the full heading text on the same line as the opening `<h1>` tag, so MDX treats the children as inline content instead of block content. No visible text or class changes; `<span className="dw-hl">` styling is untouched.

```diff
-      <h1 className="dw-verdict" style={{ marginTop: '6px' }}>
-        We write down what we build, break, and figure out, <span className="dw-hl">before we forget it</span>.
-      </h1>
+      <h1 className="dw-verdict" style={{ marginTop: '6px' }}>We write down what we build, break, and figure out, <span className="dw-hl">before we forget it</span>.</h1>
```

Checked the rest of `index.mdx` for the same pattern: this is the only heading element in the file, no other instances to fix.

## Verification

Compiled `index.mdx` (frontmatter stripped, matching how `getMdxSource` invokes `serialize`) through the actual `@mdx-js/mdx@3.1.1` package pinned in `foundation-apps/apps/memo`'s pnpm store, both before and after the edit:

- Before: h1's `children` is `_jsxs(_components.p, { children: [...] })`, a paragraph node, matches the bad production output byte for byte.
- After: h1's `children` is a plain array `["We write down what we build, break, and figure out, ", _jsx("span", {...}), "."]`, no paragraph wrapper.

This confirms the compiled JSX shape changes as intended using the real memo build's MDX version. It does not run a full Next.js render or hit a live is-agentic.com scan, that only happens on the next memo.d.foundation deploy after merge.
